### PR TITLE
CentOS 8 and Fedora kmod Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# tools-install-ansible
+sysdig-ansible
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# defaults file for ansible-sysdig
+role_version: 0.0.1
+
+sysdig_agent_access_key: llsdkjfsdlfj
+sysdig_api_key: 2398423948
+sysdig_region: us1
+sysdig_proxy:
+sysdig_agent_mode: platform
+sysdig_agent_settings: ""
+sysdig_agent_driver: "kmodule"
+sysdig_agent_version: "12.12.1"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for ansible-sysdig

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,64 @@
+galaxy_info:
+  author: sysdig
+  description: Ansible Role for deployment and management of the Sysdig Agent and Host Scanner
+  company: Sysdig, Inc.
+  role_name: ansible_sysdig
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: Apache-2.0
+
+  min_ansible_version: "2.12"
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+   - name: Amazon Linux 2
+     versions:
+      - all
+   - name: Debian
+     versions:
+     - jessie
+     - stretch
+     - buster
+     - bullseye
+   - name: EL
+     versions:
+     - "7"
+     - "8"
+     - "9"
+   - name: Ubuntu
+     versions:
+     - bionic
+     - focal
+     - jammy
+
+  galaxy_tags:
+    - monitoring
+    - security
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/tasks/agent/configure-agent-requirements.yml
+++ b/tasks/agent/configure-agent-requirements.yml
@@ -1,0 +1,11 @@
+- name: Configure Sysdig Agent rpm Repository
+  include_tasks: agent/dependencies/repositories/configure-rpm-repo.yml
+  when: ansible_pkg_mgr == "dnf" or ansible_pkg_mgr == "yum"
+
+- name: Install Kernel Headers
+  include_tasks: agent/dependencies/kernel-headers/install-kernel-headers.yml
+
+- name: Enable epel and Install dkms
+  include_tasks: agent/dependencies/kmodule/install-kmodule-deps.yml
+  when:
+    - sysdig_agent_driver == "kmodule"

--- a/tasks/agent/configure-sysdig-agent.yml
+++ b/tasks/agent/configure-sysdig-agent.yml
@@ -1,0 +1,8 @@
+---
+- name: Create dragent.yaml file
+  template:
+    src: dragent.yaml.j2
+    dest: "/opt/draios/etc/dragent.yaml"
+    owner: root
+    group: root
+    mode: 0644

--- a/tasks/agent/dependencies/kernel-headers/install-kernel-headers.yml
+++ b/tasks/agent/dependencies/kernel-headers/install-kernel-headers.yml
@@ -1,0 +1,15 @@
+---
+- name: Install Kernel Headers (rpm)
+  include_tasks: agent/dependencies/kernel-headers/redhat/install-rh-{{ kernel_type }}-headers.yml
+  when:
+    - ansible_kernel_version | regex_search(match_str)
+    - ansible_facts.os_family == "RedHat"
+  vars:
+    - match_str: PAE
+      kernel_type: pae
+    - match_str: vzkernel
+      kernel_type: vzkernel
+    - match_str: uek
+      kernel_type: uek
+    - match_str: .*
+      kernel_type: kernel-devel

--- a/tasks/agent/dependencies/kernel-headers/redhat/install-rh-headers.yml
+++ b/tasks/agent/dependencies/kernel-headers/redhat/install-rh-headers.yml
@@ -1,0 +1,28 @@
+---
+- name: Install PAE Headers
+  ansible.builtin.package:
+    name: kernel-PAE-devel-{{ ansible_kernel }}
+    state: present
+  register: pae_kernel
+  when: '"PAE" in ansible_kernel'
+
+- name: Install OpenVZ Headers
+  ansible.builtin.package:
+    name: vzkernel-devel-{{ ansible_kernel }}
+    state: present
+  register: openvz_kernel
+  when: '"stab" in ansible_kernel'
+
+- name: Install UEK Headers
+  ansible.builtin.package:
+    name: kernel-uek-devel-{{ ansible_kernel }}
+    state: present
+  register: uek_kernel
+  when: '"uek" in ansible_kernel'
+
+- name: Install Kernel Headers
+  include:
+  ansible.builtin.package:
+    name: kernel-devel-{{ ansible_kernel }}
+    state: present
+  when: pae_kernel is skipped and openvz_kernel is skipped and uek_kernel is skipped

--- a/tasks/agent/dependencies/kernel-headers/redhat/install-rh-kernel-devel-headers.yml
+++ b/tasks/agent/dependencies/kernel-headers/redhat/install-rh-kernel-devel-headers.yml
@@ -1,0 +1,5 @@
+---
+- name: Install Standard Headers
+  ansible.builtin.package:
+    name: kernel-devel-{{ ansible_kernel }}
+    state: present

--- a/tasks/agent/dependencies/kernel-headers/redhat/install-rh-pae-headers.yml
+++ b/tasks/agent/dependencies/kernel-headers/redhat/install-rh-pae-headers.yml
@@ -1,0 +1,5 @@
+---
+- name: Install PAE Headers
+  ansible.builtin.package:
+    name: kernel-PAE-devel-{{ ansible_kernel }}
+    state: present

--- a/tasks/agent/dependencies/kernel-headers/redhat/install-rh-uek-headers.yml
+++ b/tasks/agent/dependencies/kernel-headers/redhat/install-rh-uek-headers.yml
@@ -1,0 +1,5 @@
+---
+- name: Install UEK Headers
+  ansible.builtin.package:
+    name: kernel-uek-devel-{{ ansible_kernel }}
+    state: present

--- a/tasks/agent/dependencies/kernel-headers/redhat/install-rh-vzkernel-headers.yml
+++ b/tasks/agent/dependencies/kernel-headers/redhat/install-rh-vzkernel-headers.yml
@@ -1,0 +1,5 @@
+---
+- name: Install OpenVZ Headers
+  ansible.builtin.package:
+    name: vzkernel-devel-{{ ansible_kernel }}
+    state: present

--- a/tasks/agent/dependencies/kmodule/install-kmodule-deps.yml
+++ b/tasks/agent/dependencies/kmodule/install-kmodule-deps.yml
@@ -1,0 +1,4 @@
+- name: Install Kernel Module Dependencies
+  include_tasks: agent/dependencies/kmodule/redhat/install-rh-kmodule-deps.yml
+  when:
+    - ansible_facts.os_family == "RedHat"

--- a/tasks/agent/dependencies/kmodule/redhat/install-rh-kmodule-deps.yml
+++ b/tasks/agent/dependencies/kmodule/redhat/install-rh-kmodule-deps.yml
@@ -1,0 +1,12 @@
+- name: Enable epel
+  ansible.builtin.package:
+    name: epel-release
+    state: latest
+  when:
+    - ansible_facts.distribution != "Fedora"
+
+- name: Install dkms
+  ansible.builtin.package:
+    name:
+      - dkms
+    state: latest

--- a/tasks/agent/dependencies/repositories/configure-rpm-repo.yml
+++ b/tasks/agent/dependencies/repositories/configure-rpm-repo.yml
@@ -1,0 +1,7 @@
+---
+- name: Add Sysdig Agent Repository
+  ansible.builtin.yum_repository:
+    baseurl: https://download.sysdig.com/stable/rpm/$basearch
+    description: Sysdig Agent Repository
+    gpgkey: https://download.sysdig.com/DRAIOS-GPG-KEY.public
+    name: draios

--- a/tasks/agent/install-sysdig-agent-rpm.yml
+++ b/tasks/agent/install-sysdig-agent-rpm.yml
@@ -1,0 +1,11 @@
+- name: Install Sysdig Agent rpm (latest)
+  ansible.builtin.package:
+    name: draios-agent
+    state: latest
+  when: sysdig_agent_version is not defined
+
+- name: Install Sysdig Agent rpm (pinned)
+  ansible.builtin.package:
+    name: draios-agent-{{ sysdig_agent_version }}
+    state: present
+  when: sysdig_agent_version is defined

--- a/tasks/agent/install-sysdig-agent.yml
+++ b/tasks/agent/install-sysdig-agent.yml
@@ -1,0 +1,10 @@
+---
+- name: Install Sysdig Agent (rpm)
+  include_tasks: agent/install-sysdig-agent-rpm.yml
+  when: ansible_pkg_mgr == "dnf" or ansible_pkg_mgr == "yum"
+
+- name: Start dragent Service
+  service:
+    name: dragent
+    enabled: true
+    state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Install Sysdig Agent
+  block:
+    - name: Configure Installation Requirements
+      include_tasks: agent/configure-agent-requirements.yml
+
+    - name: Install Sysdig Agent
+      include_tasks: agent/install-sysdig-agent.yml
+  when: install_sysdig_agent
+
+- name: Configure Sysdig Agent
+  include_tasks: agent/configure-sysdig-agent.yml

--- a/templates/agent_helpers.j2
+++ b/templates/agent_helpers.j2
@@ -1,0 +1,48 @@
+{%- macro mode_settings(mode) -%}
+{%- if mode == 'secure' -%}
+feature:
+  mode: secure
+app_checks_enabled: false
+jmx:
+  enabled: false
+prometheus:
+  enabled: false
+statsd:
+  enabled: false
+{%- elif mode == 'monitor' -%}
+feature:
+  mode: monitor
+commandlines_capture:
+  enabled: false
+drift_killer:
+  enabled: false
+falcobaseline:
+  enabled: false
+memdump:
+  enabled: false
+network_topology:
+  enabled: false
+secure_audit_streams:
+  enabled: false
+{%- elif mode == 'secure_light' -%}
+feature:
+  mode: secure_light
+app_checks_enabled: false
+drift_killer:
+  enabled: false
+falcobaseline:
+  enabled: false
+jmx:
+  enabled: false
+memdump:
+  enabled: false
+network_topology:
+  enabled: false
+prometheus:
+  enabled: false
+secure_audit_streams:
+  enabled: false
+statsd:
+  enabled: false
+{%- endif -%}
+{% endmacro -%}

--- a/templates/dragent.yaml.j2
+++ b/templates/dragent.yaml.j2
@@ -1,0 +1,10 @@
+{% import 'agent_helpers.j2' as agent -%}
+collector_endpoint: {{ collector_url | default("https://collector.sysdigcloud.com") }}
+customerid: {{ agent_access_key | default("CHANGE-ME") }}
+{% if 'cointerface' not in sysdig_agent_settings -%}
+cointerface: false
+{% endif %}
+{{ agent.mode_settings(sysdig_agent_mode | default('', true)) }}
+{% if sysdig_agent_settings | default({}, true) | length > 0 %}
+{{ sysdig_agent_settings | to_nice_yaml }}
+{%- endif -%}

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ansible-sysdig

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for ansible-sysdig


### PR DESCRIPTION
Initial commit of support for Installing the Sysdig Agent on Red Hat derived distributions. Support has been tested on CentOS 8 and Fedora 37.

Features working:
* Configure Sysdig Agent RPM repositories
* Install Agent w/ kmodule support
* Configure newly installed or existing Agents