### PR TITLE
Add support for running tests through Molecule

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/molecule/agent/INSTALL.rst
+++ b/molecule/agent/INSTALL.rst
@@ -1,0 +1,22 @@
+*********************************************
+Amazon Web Services driver installation guide
+*********************************************
+
+Requirements
+============
+
+* An AWS credentials rc file
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule-ec2'

--- a/molecule/agent/converge.yml
+++ b/molecule/agent/converge.yml
@@ -1,0 +1,16 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include tools-install-ansible"
+      include_role:
+        name: "tools-install-ansible"
+        apply:
+          become: true
+      vars:
+        install_sysdig_agent: true
+        sysdig_agent_access_key: 12345
+        sysdig_region: us1
+        sysdig_agent_mode: platform
+        sysdig_agent_driver: "kmodule"
+        sysdig_agent_version: "12.13.0"

--- a/molecule/agent/create.yml
+++ b/molecule/agent/create.yml
@@ -1,0 +1,321 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  collections:
+    - community.aws
+    - community.crypto
+  vars:
+    # Run config handling
+    default_run_id: "{{ lookup('password', '/dev/null chars=ascii_lowercase length=5') }}"
+    default_run_config:
+      run_id: "{{ default_run_id }}"
+
+    run_config_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/run-config.yml"
+    run_config_from_file: "{{ (lookup('file', run_config_path, errors='ignore') or '{}') | from_yaml }}"
+    run_config: '{{ default_run_config | combine(run_config_from_file) }}'
+
+    # Platform settings handling
+    default_assign_public_ip: true
+    default_aws_profile: "{{ lookup('env', 'AWS_PROFILE') }}"
+    default_boot_wait_seconds: 120
+    default_instance_type: t3a.medium
+    default_key_inject_method: cloud-init # valid values: [cloud-init, ec2]
+    default_key_name: "molecule-{{ run_config.run_id }}"
+    default_private_key_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/id_rsa"
+    default_public_key_path: "{{ default_private_key_path }}.pub"
+    default_ssh_user: ansible
+    default_ssh_port: 22
+    default_user_data: ''
+
+    default_security_group_name: "molecule-{{ run_config.run_id }}"
+    default_security_group_description: Ephemeral security group for Molecule instances
+    default_security_group_rules:
+      - proto: tcp
+        from_port: "{{ default_ssh_port }}"
+        to_port: "{{ default_ssh_port }}"
+        cidr_ip: "0.0.0.0/0"
+      - proto: icmp
+        from_port: 8
+        to_port: -1
+        cidr_ip: "0.0.0.0/0"
+    default_security_group_rules_egress:
+      - proto: -1
+        from_port: 0
+        to_port: 0
+        cidr_ip: "0.0.0.0/0"
+
+    platform_defaults:
+      assign_public_ip: "{{ default_assign_public_ip }}"
+      aws_profile: "{{ default_aws_profile }}"
+      boot_wait_seconds: "{{ default_boot_wait_seconds }}"
+      instance_type: "{{ default_instance_type }}"
+      key_inject_method: "{{ default_key_inject_method }}"
+      key_name: "{{ default_key_name }}"
+      private_key_path: "{{ default_private_key_path }}"
+      public_key_path: "{{ default_public_key_path }}"
+      security_group_name: "{{ default_security_group_name }}"
+      security_group_description: "{{ default_security_group_description }}"
+      security_group_rules: "{{ default_security_group_rules }}"
+      security_group_rules_egress: "{{ default_security_group_rules_egress }}"
+      ssh_user: "{{ default_ssh_user }}"
+      ssh_port: "{{ default_ssh_port }}"
+      cloud_config: {}
+      image: ""
+      image_name: ""
+      image_owner: [self]
+      name: ""
+      region: ""
+      security_groups: []
+      tags: {}
+      volumes: []
+      vpc_id: ""
+      vpc_subnet_id: ""
+
+    # Merging defaults into a list of dicts is, it turns out, not straightforward
+    platforms: >-
+      {{ [platform_defaults | dict2items]
+           | product(molecule_yml.platforms | map('dict2items') | list)
+           | map('flatten', levels=1)
+           | list
+           | map('items2dict')
+           | list }}
+  pre_tasks:
+    - name: Validate platform configurations
+      assert:
+        that:
+          - platforms | length > 0
+          - platform.name is string and platform.name | length > 0
+          - platform.assign_public_ip is boolean
+          - platform.aws_profile is string
+          - platform.boot_wait_seconds is integer and platform.boot_wait_seconds >= 0
+          - platform.cloud_config is mapping
+          - platform.image is string
+          - platform.image_name is string
+          - platform.image_owner is sequence or (platform.image_owner is string and platform.image_owner | length > 0)
+          - platform.instance_type is string and platform.instance_type | length > 0
+          - platform.key_inject_method is in ["cloud-init", "ec2"]
+          - platform.key_name is string and platform.key_name | length > 0
+          - platform.private_key_path is string and platform.private_key_path | length > 0
+          - platform.public_key_path is string and platform.public_key_path | length > 0
+          - platform.region is string
+          - platform.security_group_name is string and platform.security_group_name | length > 0
+          - platform.security_group_description is string and platform.security_group_description | length > 0
+          - platform.security_group_rules is sequence
+          - platform.security_group_rules_egress is sequence
+          - platform.security_groups is sequence
+          - platform.ssh_user is string and platform.ssh_user | length > 0
+          - platform.ssh_port is integer and platform.ssh_port in range(1, 65536)
+          - platform.tags is mapping
+          - platform.volumes is sequence
+          - platform.vpc_id is string
+          - platform.vpc_subnet_id is string and platform.vpc_subnet_id | length > 0
+        quiet: true
+      loop: '{{ platforms }}'
+      loop_control:
+        loop_var: platform
+        label: "{{ platform.name }}"
+  tasks:
+    - name: Write run config to file
+      copy:
+        dest: "{{ run_config_path }}"
+        content: "{{ run_config | to_yaml }}"
+
+    - name: Generate local key pairs
+      openssh_keypair:
+        path: "{{ item.private_key_path }}"
+        type: rsa
+        size: 2048
+        regenerate: never
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: local_keypairs
+
+    - name: Look up EC2 AMI(s) by owner and name (if image not set)
+      ec2_ami_info:
+        owners: "{{ item.image_owner }}"
+        filters: "{{ item.image_filters | default({}) | combine(image_name_map) }}"
+      vars:
+        image_name_map: "{% if item.image_name is defined and item.image_name | length > 0 %}{{ { 'name': item.image_name } }}{% else %}{}{% endif %}"
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not item.image
+      register: ami_info
+
+    - name: Look up subnets to determine VPCs (if needed)
+      ec2_vpc_subnet_info:
+        subnet_ids: "{{ item.vpc_subnet_id }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not item.vpc_id
+      register: subnet_info
+
+    - name: Validate discovered information
+      assert:
+        that:
+          - platform.image or (ami_info.results[index].images | length > 0)
+          - platform.vpc_id or (subnet_info.results[index].subnets | length > 0)
+        quiet: true
+      loop: "{{ platforms }}"
+      loop_control:
+        loop_var: platform
+        index_var: index
+        label: "{{ platform.name }}"
+
+    - name: Create ephemeral EC2 keys (if needed)
+      ec2_key:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        name: "{{ item.key_name }}"
+        key_material: "{{ local_keypair.public_key }}"
+      vars:
+        local_keypair: "{{ local_keypairs.results[index] }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      when: item.key_inject_method == "ec2"
+      register: ec2_keys
+
+    - name: Create ephemeral security groups (if needed)
+      ec2_group:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
+        name: "{{ item.security_group_name }}"
+        description: "{{ item.security_group_description }}"
+        rules: "{{ item.security_group_rules }}"
+        rules_egress: "{{ item.security_group_rules_egress }}"
+      vars:
+        vpc_subnet: "{{ subnet_info.results[index].subnets[0] }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      when: item.security_groups | length == 0
+
+    - name: Create ephemeral EC2 instance(s)
+      ec2_instance:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        filters: "{{ platform_filters }}"
+        instance_type: "{{ item.instance_type }}"
+        image_id: "{{ platform_image_id }}"
+        vpc_subnet_id: "{{ item.vpc_subnet_id }}"
+        security_groups: "{{ platform_security_groups }}"
+        network:
+          assign_public_ip: "{{ item.assign_public_ip }}"
+        volumes: "{{ item.volumes }}"
+        key_name: "{{ (item.key_inject_method == 'ec2') | ternary(item.key_name, omit) }}"
+        tags: "{{ platform_tags }}"
+        user_data: "{{ platform_user_data }}"
+        state: "running"
+        wait: true
+      vars:
+        platform_security_groups: "{{ item.security_groups or [item.security_group_name] }}"
+        platform_generated_image_id: "{{ (ami_info.results[index].images | sort(attribute='creation_date', reverse=True))[0].image_id }}"
+        platform_image_id: "{{ item.image or platform_generated_image_id }}"
+
+        platform_generated_cloud_config:
+          users:
+            - name: "{{ item.ssh_user }}"
+              ssh_authorized_keys:
+                - "{{ local_keypairs.results[index].public_key }}"
+              sudo: "ALL=(ALL) NOPASSWD:ALL"
+        platform_cloud_config: >-
+          {{ (item.key_inject_method == 'cloud-init')
+               | ternary((item.cloud_config | combine(platform_generated_cloud_config)), item.cloud_config) }}
+        platform_user_data: |-
+          #cloud-config
+          {{ platform_cloud_config | to_yaml }}
+
+        platform_generated_tags:
+          instance: "{{ item.name }}"
+          "molecule-run-id": "{{ run_config.run_id }}"
+        platform_tags: "{{ (item.tags or {}) | combine(platform_generated_tags) }}"
+        platform_filter_keys: "{{ platform_generated_tags.keys() | map('regex_replace', '^(.+)$', 'tag:\\1') }}"
+        platform_filters: "{{ dict(platform_filter_keys | zip(platform_generated_tags.values())) }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      register: ec2_instances_async
+      async: 7200
+      poll: 0
+
+    - block:
+        - name: Wait for instance creation to complete
+          async_status:
+            jid: "{{ item.ansible_job_id }}"
+          loop: "{{ ec2_instances_async.results }}"
+          loop_control:
+            index_var: index
+            label: "{{ platforms[index].name }}"
+          register: ec2_instances
+          until: ec2_instances is finished
+          retries: 300
+
+        - name: Collect instance configs
+          set_fact:
+            instance_config:
+              instance: "{{ item.name }}"
+              address: "{{ item.assign_public_ip | ternary(instance.public_ip_address, instance.private_ip_address) }}"
+              user: "{{ item.ssh_user }}"
+              port: "{{ item.ssh_port }}"
+              identity_file: "{{ item.private_key_path }}"
+              instance_ids:
+                - "{{ instance.instance_id }}"
+          vars:
+            instance: "{{ ec2_instances.results[index].instances[0] }}"
+          loop: "{{ platforms }}"
+          loop_control:
+            index_var: index
+            label: "{{ item.name }}"
+          register: instance_configs
+
+        - name: Write Molecule instance configs
+          copy:
+            dest: "{{ molecule_instance_config }}"
+            content: >-
+              {{ instance_configs.results
+                   | map(attribute='ansible_facts.instance_config')
+                   | list
+                   | to_json
+                   | from_json
+                   | to_yaml }}
+
+        - name: Start SSH pollers
+          wait_for:
+            host: "{{ item.address }}"
+            port: "{{ item.port }}"
+            search_regex: SSH
+            delay: 10
+            timeout: 320
+          loop: "{{ instance_configs.results | map(attribute='ansible_facts.instance_config') | list }}"
+          loop_control:
+            label: "{{ item.instance }}"
+          register: ssh_wait_async
+          async: 300
+          poll: 0
+
+        - name: Wait for SSH
+          async_status:
+            jid: "{{ item.ansible_job_id }}"
+          loop: "{{ ssh_wait_async.results }}"
+          loop_control:
+            index_var: index
+            label: "{{ platforms[index].name }}"
+          register: ssh_wait
+          until: ssh_wait_async is finished
+          retries: 300
+          delay: 1
+
+        - name: Wait for boot process to finish
+          pause:
+            seconds: "{{ platforms | map(attribute='boot_wait_seconds') | max }}"
+      when: ec2_instances_async is changed

--- a/molecule/agent/destroy.yml
+++ b/molecule/agent/destroy.yml
@@ -1,0 +1,142 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  collections:
+    - community.aws
+  vars:
+    # Run config handling
+    default_run_id: "{{ lookup('password', '/dev/null chars=ascii_lowercase length=5') }}"
+    default_run_config:
+      run_id: "{{ default_run_id }}"
+
+    run_config_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/run-config.yml"
+    run_config_from_file: "{{ (lookup('file', run_config_path, errors='ignore') or '{}') | from_yaml }}"
+    run_config: '{{ default_run_config | combine(run_config_from_file) }}'
+
+    # Platform settings handling
+    default_aws_profile: "{{ lookup('env', 'AWS_PROFILE') }}"
+    default_key_inject_method: cloud-init # valid values: [cloud-init, ec2]
+    default_key_name: "molecule-{{ run_config.run_id }}"
+    default_security_group_name: "molecule-{{ run_config.run_id }}"
+
+    platform_defaults:
+      aws_profile: "{{ default_aws_profile }}"
+      key_inject_method: "{{ default_key_inject_method }}"
+      key_name: "{{ default_key_name }}"
+      region: ""
+      security_group_name: "{{ default_security_group_name }}"
+      security_groups: []
+      vpc_id: ""
+      vpc_subnet_id: ""
+
+    # Merging defaults into a list of dicts is, it turns out, not straightforward
+    platforms: >-
+      {{ [platform_defaults | dict2items]
+           | product(molecule_yml.platforms | map('dict2items') | list)
+           | map('flatten', levels=1)
+           | list
+           | map('items2dict')
+           | list }}
+
+    # Stored instance config
+    instance_config: "{{ (lookup('file', molecule_instance_config, errors='ignore') or '{}') | from_yaml }}"
+  pre_tasks:
+    - name: Validate platform configurations
+      assert:
+        that:
+          - platforms | length > 0
+          - platform.name is string and platform.name | length > 0
+          - platform.aws_profile is string
+          - platform.key_inject_method is in ["cloud-init", "ec2"]
+          - platform.key_name is string and platform.key_name | length > 0
+          - platform.region is string
+          - platform.security_group_name is string and platform.security_group_name | length > 0
+          - platform.security_groups is sequence
+          - platform.vpc_id is string
+          - platform.vpc_subnet_id is string and platform.vpc_subnet_id | length > 0
+        quiet: true
+      loop: '{{ platforms }}'
+      loop_control:
+        loop_var: platform
+        label: "{{ platform.name }}"
+  tasks:
+    - name: Look up subnets to determine VPCs (if needed)
+      ec2_vpc_subnet_info:
+        subnet_ids: "{{ item.vpc_subnet_id }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not item.vpc_id
+      register: subnet_info
+
+    - name: Validate discovered information
+      assert:
+        that: platform.vpc_id or (subnet_info.results[index].subnets | length > 0)
+        quiet: true
+      loop: "{{ platforms }}"
+      loop_control:
+        loop_var: platform
+        index_var: index
+        label: "{{ platform.name }}"
+
+    - name: Destroy ephemeral EC2 instances
+      ec2_instance:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        instance_ids: "{{ instance_config | map(attribute='instance_ids') | flatten }}"
+        vpc_subnet_id: "{{ item.vpc_subnet_id }}"
+        state: absent
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: ec2_instances_async
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance destruction to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      loop: "{{ ec2_instances_async.results }}"
+      loop_control:
+        index_var: index
+        label: "{{ platforms[index].name }}"
+      register: ec2_instances
+      until: ec2_instances is finished
+      retries: 300
+
+    - name: Write Molecule instance configs
+      copy:
+        dest: "{{ molecule_instance_config }}"
+        content: "{{ {} | to_yaml }}"
+
+    - name: Destroy ephemeral security groups (if needed)
+      ec2_group:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
+        name: "{{ item.security_group_name }}"
+        state: absent
+      vars:
+        vpc_subnet: "{{ subnet_info.results[index].subnets[0] }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      when: item.security_groups | length == 0
+
+    - name: Destroy ephemeral keys (if needed)
+      #ec2_key:
+      #  profile: "{{ item.aws_profile | default(omit) }}"
+      #  region: "{{ item.region | default(omit) }}"
+      #  name: "{{ item.key_name }}"
+      #  state: absent
+      shell:
+        cmd: echo ${{ item.name }}
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      when: item.key_inject_method == "ec2"

--- a/molecule/agent/molecule.yml
+++ b/molecule/agent/molecule.yml
@@ -1,0 +1,62 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+lint: |
+  set -e
+  ansible-lint tasks/agent
+  yamllint tasks/agent
+platforms:
+  - name: amzn2
+    image_name: amzn2-ami-kernel-5.10*gp2
+    image_filters:
+      architecture: x86_64
+    image_owner: "137112412989"  # Amazon
+    instance_type: {{ instance_type }}
+    region: {{ aws_region }}
+    vpc_subnet_id: {{ vpc_subnet_id }}
+  - name: al2023
+    image_name: al2023-ami*
+    image_filters:
+      architecture: x86_64
+    image_owner: "137112412989"  # Amazon
+    instance_type: {{ instance_type }}
+    region: {{ aws_region }}
+    vpc_subnet_id: {{ vpc_subnet_id }}
+  - name: centos7
+    image_filters:
+      architecture: x86_64
+    image_name: "CentOS Linux 7*"
+    image_owner: "125523088429"  # Red Hat CPE
+    instance_type: {{ instance_type }}
+    region: {{ aws_region }}
+    vpc_subnet_id: {{ vpc_subnet_id }}
+  - name: centos8
+    image_filters:
+      architecture: x86_64
+    image_name: "CentOS Stream 8*"
+    image_owner: "125523088429"  # Red Hat CPE
+    instance_type: {{ instance_type }}
+    vpc_subnet_id: {{ vpc_subnet_id }}
+  - name: centos9
+    image_filters:
+      architecture: x86_64
+    image_name: "CentOS Stream 9*"
+    image_owner: "125523088429"  # Red Hat CPE
+    instance_type: {{ instance_type }}
+    region: {{ aws_region }}
+    vpc_subnet_id: {{ vpc_subnet_id }}
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: agent
+  test_sequence:
+    - create
+    - converge
+    - verify
+    - destroy
+verifier:
+  name: ansible

--- a/molecule/agent/prepare.yml
+++ b/molecule/agent/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Make sure python3 is installed
+      package:
+        name: python3
+        state: present
+      become: true

--- a/molecule/agent/verify.yml
+++ b/molecule/agent/verify.yml
@@ -1,0 +1,10 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Example assertion
+    ansible.builtin.assert:
+      that: true

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -1,0 +1,15 @@
+***********************************
+Delegated driver installation guide
+***********************************
+
+Requirements
+============
+
+This driver is delegated to the developer.  Up to the developer to implement
+requirements.
+
+Install
+=======
+
+This driver is delegated to the developer.  Up to the developer to implement
+requirements.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: "Include tools-install-ansible"
+      ansible.builtin.include_role:
+        name: "tools-install-ansible"

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -1,0 +1,35 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+
+    # TODO: Developer must implement and populate 'server' variable
+
+    - when: server.changed | default(false) | bool
+      block:
+        - name: Populate instance config dict
+          ansible.builtin.set_fact:
+            instance_conf_dict: {
+              'instance': "{{ }}",
+              'address': "{{ }}",
+              'user': "{{ }}",
+              'port': "{{ }}",
+              'identity_file': "{{ }}", }
+          with_items: "{{ server.results }}"
+          register: instance_config_dict
+
+        - name: Convert instance config dict to a list
+          ansible.builtin.set_fact:
+            instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+
+        - name: Dump instance config
+          ansible.builtin.copy:
+            content: |
+              # Molecule managed
+
+              {{ instance_conf | to_json | from_json | to_yaml }}
+            dest: "{{ molecule_instance_config }}"
+            mode: 0600

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -1,0 +1,24 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    # Developer must implement.
+
+    # Mandatory configuration for Molecule to function.
+
+    - name: Populate instance config
+      ansible.builtin.set_fact:
+        instance_conf: {}
+
+    - name: Dump instance config
+      ansible.builtin.copy:
+        content: |
+          # Molecule managed
+
+          {{ instance_conf | to_json | from_json | to_yaml }}
+        dest: "{{ molecule_instance_config }}"
+        mode: 0600
+      when: server.changed | default(false) | bool

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Example assertion
+    ansible.builtin.assert:
+      that: true


### PR DESCRIPTION
This commit introduces the 'agent' test scenario that can be run with the following command:
```
molecule test -s agent
```
Before the tests can be run, the instance type, region, and vpc information in molecule/agent/molecule.yml needs to be populated. The GH Actions added in a future commit will handle that automatically for CI runs.