### PR TITLE
Add support for Amazon Linux 2023

### DIFF
--- a/tasks/agent/configure-agent-requirements.yml
+++ b/tasks/agent/configure-agent-requirements.yml
@@ -9,3 +9,11 @@
   include_tasks: agent/dependencies/kmodule/install-kmodule-deps.yml
   when:
     - sysdig_agent_driver == "kmodule"
+
+- name: Install Distribution Specific Dependencies
+  include_tasks: agent/dependencies/os-specific/install-os-dependencies.yml
+  # These checks below will need to be enhanced later to be more generic.
+  # Right now this is the only distribution that requires an extra step.
+  when:
+    - ansible_facts.distribution == "Amazon"
+    - ansible_facts.distribution_version == "2023"

--- a/tasks/agent/dependencies/kmodule/redhat/install-rh-kmodule-deps.yml
+++ b/tasks/agent/dependencies/kmodule/redhat/install-rh-kmodule-deps.yml
@@ -3,7 +3,7 @@
     name: epel-release
     state: latest
   when:
-    - ansible_facts.distribution != "Fedora"
+    - ansible_facts.distribution not in ["Amazon", "Fedora"]
 
 - name: Install dkms
   ansible.builtin.package:

--- a/tasks/agent/dependencies/os-specific/amazon/install-amazon-dependencies.yml
+++ b/tasks/agent/dependencies/os-specific/amazon/install-amazon-dependencies.yml
@@ -1,0 +1,6 @@
+---
+- name: Install chkconfig
+  yum:
+    name: chkconfig
+    state: present
+  when: ansible_facts.distribution_version == "2023"

--- a/tasks/agent/dependencies/os-specific/install-os-dependencies.yml
+++ b/tasks/agent/dependencies/os-specific/install-os-dependencies.yml
@@ -1,0 +1,5 @@
+- name: Install OS Specific Dependencies
+  include_tasks: agent/dependencies/os-specific/{{ distribution }}/install-{{ distribution }}-dependencies.yml
+  when: ansible_facts.distribution | lower | regex_search(distribution)
+  vars:
+    - distribution: amazon


### PR DESCRIPTION
AL2023 has slightly different behavior than some other RedHat derived distributions. The differences are:

* The `chkconfig` package needs to be present in order for the Agent's SysV init scripts to be translated into systemd services, but that package is not installed by default on the AL2023 platform.
* The EPEL does not need to be installed on any Amazon linux distribution