### PR TITLE
Correct dragent.yaml key for collector url

### DIFF
--- a/templates/dragent.yaml.j2
+++ b/templates/dragent.yaml.j2
@@ -1,5 +1,5 @@
 {% import 'agent_helpers.j2' as agent -%}
-collector_endpoint: {{ collector_url | default("https://collector.sysdigcloud.com") }}
+collector: {{ collector_url | default("https://collector.sysdigcloud.com") }}
 customerid: {{ agent_access_key | default("CHANGE-ME") }}
 {% if 'cointerface' not in sysdig_agent_settings -%}
 cointerface: false


### PR DESCRIPTION
The template for the dragent.yaml file had an incorrect key for the collector url. This lead to the agents defaulting to attempting to connect to US1 instead of the desired address.