### PR TITLE
Debian family kmodule support

### DIFF
--- a/molecule/agent/converge.yml
+++ b/molecule/agent/converge.yml
@@ -9,7 +9,8 @@
           become: true
       vars:
         install_sysdig_agent: true
-        sysdig_agent_access_key: 12345
+        sysdig_agent_install_build_dependencies: true
+        agent_access_key: 12345
         sysdig_region: us1
         sysdig_agent_mode: platform
         sysdig_agent_driver: "kmodule"

--- a/molecule/agent/molecule.yml
+++ b/molecule/agent/molecule.yml
@@ -8,6 +8,46 @@ lint: |
   ansible-lint tasks/agent
   yamllint tasks/agent
 platforms:
+  - name: debian-10
+    image_name: "debian-10-amd64*"
+    image_filters:
+      architecture: x86_64
+    image_owner: "136693071363"  # Debian
+    instance_type: {{ instance_type }}
+    region: {{ aws_region }}
+    vpc_subnet_id: {{ vpc_subnet_id }}
+  - name: debian-11
+    image_name: "debian-11-amd64*"
+    image_filters:
+      architecture: x86_64
+    image_owner: "136693071363"  # Debian
+    instance_type: {{ instance_type }}
+    region: {{ aws_region }}
+    vpc_subnet_id: {{ vpc_subnet_id }}
+  - name: ubuntu-1804
+    image_name: "*ubuntu-bionic-18.04*"
+    image_filters:
+      architecture: x86_64
+    image_owner: "099720109477"  # Canonical
+    instance_type: {{ instance_type }}
+    region: {{ aws_region }}
+    vpc_subnet_id: {{ vpc_subnet_id }}
+  - name: ubuntu-2004
+    image_name: "*ubuntu-focal-20.04*"
+    image_filters:
+      architecture: x86_64
+    image_owner: "099720109477"  # Canonical
+    instance_type: {{ instance_type }}
+    region: {{ aws_region }}
+    vpc_subnet_id: {{ vpc_subnet_id }}
+  - name: ubuntu-2204
+    image_name: "*ubuntu-jammy-22.04*"
+    image_filters:
+     architecture: x86_64
+    image_owner: "099720109477"  # Canonical
+    instance_type: {{ instance_type }}
+    region: {{ aws_region }}
+    vpc_subnet_id: {{ vpc_subnet_id }}
   - name: amzn2
     image_name: amzn2-ami-kernel-5.10*gp2
     image_filters:

--- a/molecule/agent/prepare.yml
+++ b/molecule/agent/prepare.yml
@@ -1,7 +1,7 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: false
+  gather_facts: true
   become: true
   tasks:
     - name: Make sure python3 is installed
@@ -10,9 +10,17 @@
         state: present
 
     - name: Update Systems
-      package:
+      ansible.builtin.yum:
         name: "*"
         state: latest
+      when: ansible_pkg_mgr in ['dnf', 'yum']
+
+    - name: Update Systems
+      ansible.builtin.apt:
+        name: "*"
+        update_cache: true
+        state: latest
+      when: ansible_pkg_mgr == "apt"
 
     - name: Reboot
       reboot:

--- a/molecule/agent/tests/test_connection.py
+++ b/molecule/agent/tests/test_connection.py
@@ -1,5 +1,7 @@
 import yaml
 
+from retry import retry
+
 # Test that the agent(s) have created a connection to the backend
 
 
@@ -12,6 +14,7 @@ def test_conn_settings(host):
     assert y["customerid"]
 
 
+@retry(tries=5, jitter=(1, 5))
 def test_be_connection(host):
     with host.sudo():
         f = host.file("/opt/draios/logs/draios.log")

--- a/tasks/agent/configure-deb-repository.yml
+++ b/tasks/agent/configure-deb-repository.yml
@@ -1,0 +1,9 @@
+---
+- name: (deb) Add Sysdig gpg Key
+  ansible.builtin.get_url:
+    url: https://download.sysdig.com/DRAIOS-GPG-KEY.public
+    dest: /etc/apt/trusted.gpg.d/sysdig.asc
+
+- name: (deb) Configure Sysdig Agent Repository
+  ansible.builtin.apt_repository:
+    repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/sysdig.asc] https://download.sysdig.com/stable/deb stable-amd64/"

--- a/tasks/agent/configure-rpm-repository.yml
+++ b/tasks/agent/configure-rpm-repository.yml
@@ -1,0 +1,7 @@
+---
+- name: (rpm) Configure Sysdig Agent Repository
+  ansible.builtin.yum_repository:
+    baseurl: https://download.sysdig.com/stable/rpm/$basearch
+    description: Sysdig Agent Repository
+    gpgkey: https://download.sysdig.com/DRAIOS-GPG-KEY.public
+    name: draios

--- a/tasks/agent/dependencies/debian/install-debian-dependencies.yml
+++ b/tasks/agent/dependencies/debian/install-debian-dependencies.yml
@@ -1,0 +1,5 @@
+---
+- name: (Debian) Install Kernel Headers
+  ansible.builtin.apt:
+    name: linux-headers-{{ ansible_kernel }}
+    state: present

--- a/tasks/agent/dependencies/ubuntu/install-ubuntu-dependencies.yml
+++ b/tasks/agent/dependencies/ubuntu/install-ubuntu-dependencies.yml
@@ -1,0 +1,5 @@
+---
+- name: (Ubuntu) Install Kernel Headers
+  ansible.builtin.apt:
+    name: linux-headers-{{ ansible_kernel }}
+    state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,16 +6,11 @@
       when: sysdig_agent_install_build_dependencies
 
     - name: Configure Sysdig Agent Repository
-      ansible.builtin.yum_repository:
-        baseurl: https://download.sysdig.com/stable/rpm/$basearch
-        description: Sysdig Agent Repository
-        gpgkey: https://download.sysdig.com/DRAIOS-GPG-KEY.public
-        name: draios
-      when: ansible_pkg_mgr in ["dnf", "yum"]
+      include_tasks: "agent/configure-{{ 'rpm' if ansible_pkg_mgr in ['dnf', 'rpm'] else 'deb' }}-repository.yml"
 
-    - name: Install Sysdig Agent (rpm)
+    - name: Install Sysdig Agent
       ansible.builtin.package:
-        name: "draios-agent{% if sysdig_agent_version is defined and sysdig_agent_version %}-{{ sysdig_agent_version }}{%endif%}"
+        name: "draios-agent{% if sysdig_agent_version is defined and sysdig_agent_version %}{% if ansible_pkg_mgr == 'apt' %}={{ sysdig_agent_version }}{% else %}-{{ sysdig_agent_version }}{% endif %}{%endif%}"
         state: latest
 
     - name: Create dragent.yaml file


### PR DESCRIPTION
* Add support for installing the Agent with kmodule support on all currently supported Debian, and Ubuntu LTS versions.