### PR TITLE
fix: correct use of rpm as a comparison against ansible_pkg_mgr

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
       when: sysdig_agent_install_build_dependencies
 
     - name: Configure Sysdig Agent Repository
-      include_tasks: "agent/configure-{{ 'rpm' if ansible_pkg_mgr in ['dnf', 'rpm'] else 'deb' }}-repository.yml"
+      include_tasks: "agent/configure-{{ 'rpm' if ansible_pkg_mgr in ['dnf', 'yum'] else 'deb' }}-repository.yml"
 
     - name: Install Sysdig Agent
       ansible.builtin.package:


### PR DESCRIPTION
main.yml had erroneously used 'rpm' in the list of stings to compare against the value of ansible_pkg_mgr to determine which repository type to configure. the issue is that the value that should be there is 'yum'. this regression was introduced as a part of adding the debian package support in pull request #12.