### PR TITLE
fix: reduce complexities of kernel devel detections for EL distros

### DIFF
--- a/tasks/agent/dependencies/almalinux/install-almalinux-dependencies.yml
+++ b/tasks/agent/dependencies/almalinux/install-almalinux-dependencies.yml
@@ -1,15 +1,8 @@
 - name: (AlmaLinux) Install Kernel Headers (8)
   ansible.builtin.dnf:
-    name: "{{ kernel_header_package }}"
+    name: "kernel-devel-{{ ansible_kernel }}"
     state: present
-  vars:
-    - match_str: uek
-      kernel_header_package: kernel-uek-devel-{{ ansible_kernel }}
-    - match_str: .*
-      kernel_header_package: kernel-devel-{{ ansible_kernel }}
-  when:
-    - ansible_kernel_version | regex_search(.match_str)
-    - ansible_distribution_major_version == "8"
+  when: ansible_distribution_major_version == "8"
 
 - name: (AlmaLinux) Install Kernel Headers (9)
   ansible.builtin.dnf:

--- a/tasks/agent/dependencies/centos/install-centos-dependencies.yml
+++ b/tasks/agent/dependencies/centos/install-centos-dependencies.yml
@@ -1,17 +1,8 @@
 - name: (CentOS) Install Kernel Headers (7/8)
   ansible.builtin.yum:
-    name: "{{ kernel_devel_package }}"
+    name: "kernel-devel-{{ ansible_kernel }}"
     state: present
-  vars:
-    - match_str: vzkernel
-      kernel_devel_package: vzkernel-devel
-    - match_str: uek
-      kernel_devel_package: kernel-uek-devel-{{ ansible_kernel }}
-    - match_str: .*
-      kernel_devel_package: kernel-devel-{{ ansible_kernel }}
-  when:
-    - ansible_kernel_version | regex_search(match_str)
-    - ansible_distribution_major_version in ["7", "8"]
+  when: ansible_distribution_major_version in ["7", "8"]
 
 - name: (CentOS) Install Kernel Headers (9)
   ansible.builtin.dnf:

--- a/tasks/agent/dependencies/rockylinux/install-rockylinux-dependencies.yml
+++ b/tasks/agent/dependencies/rockylinux/install-rockylinux-dependencies.yml
@@ -1,15 +1,8 @@
 - name: (RockyLinux) Install Kernel Headers (8)
   ansible.builtin.dnf:
-    name: "{{ kernel_header_package }}"
+    name: "kernel-devel-{{ ansible_kernel }}"
     state: present
-  vars:
-    - match_str: uek
-      kernel_header_package: kernel-uek-devel-{{ ansible_kernel }}
-    - match_str: .*
-      kernel_header_package: kernel-devel-{{ ansible_kernel }}
-  when:
-    - ansible_kernel_version | regex_search(match_str)
-    - ansible_distribution_major_version == "8"
+  when: ansible_distribution_major_version == "8"
 
 - name: (RockyLinux) Install Kernel Headers (9)
   ansible.builtin.dnf:


### PR DESCRIPTION
The `Install Kernel Headers (7/8)` steps in the AlmaLinux, CentOSLinux, and RockyLinux dependency tasks utilized `vars` to loop over the supported kernel types to determine the required kernel-devel package name. Though running `ansible-lint` it was found that the way we were using `vars`, while working, was failing schema validations as the `vars` field expects an object and not a list like we were providing. This change removes the complexities created by that logic and will instead result in needing to create a dedicated file for Oracle Linux dependencies if we choose to add support for that distribution in the Role in the future.