### PR TITLE
feat: ansible-lint compliance

### DIFF
--- a/tasks/agent/configure-deb-repository.yml
+++ b/tasks/agent/configure-deb-repository.yml
@@ -3,6 +3,7 @@
   ansible.builtin.get_url:
     url: https://download.sysdig.com/DRAIOS-GPG-KEY.public
     dest: /etc/apt/trusted.gpg.d/sysdig.asc
+    mode: 0o644
 
 - name: (deb) Configure Sysdig Agent Repository
   ansible.builtin.apt_repository:

--- a/tasks/agent/dependencies/almalinux/install-almalinux-dependencies.yml
+++ b/tasks/agent/dependencies/almalinux/install-almalinux-dependencies.yml
@@ -11,6 +11,7 @@
   when: ansible_distribution_major_version == "9"
 
 - name: (AlmaLinux) Install epel and dkms
+  when: sysdig_agent_driver == "kmodule"
   block:
     - name: Add epel GPG key
       ansible.builtin.rpm_key:
@@ -24,4 +25,3 @@
       ansible.builtin.yum:
         name: dkms
         state: present
-  when: sysdig_agent_driver == "kmodule"

--- a/tasks/agent/dependencies/amazon/install-amazon-dependencies.yml
+++ b/tasks/agent/dependencies/amazon/install-amazon-dependencies.yml
@@ -11,7 +11,7 @@
   when: sysdig_agent_driver == "kmodule"
 
 - name: (Amazon Linux) Install chkconfig
-  yum:
+  ansible.builtin.yum:
     name: chkconfig
     state: present
   when: ansible_facts.distribution_version == "2023"

--- a/tasks/agent/dependencies/centos/install-centos-dependencies.yml
+++ b/tasks/agent/dependencies/centos/install-centos-dependencies.yml
@@ -11,6 +11,7 @@
   when: ansible_distribution_major_version in ["9"]
 
 - name: (CentOS) Install epel and dkms
+  when: sysdig_agent_driver == "kmodule"
   block:
     - name: (CentOS) Add epel GPG key
       ansible.builtin.rpm_key:
@@ -25,7 +26,6 @@
       ansible.builtin.yum:
         name: dkms
         state: present
-  when: sysdig_agent_driver == "kmodule"
 
 - name: (CentOS) Install eBPF dependencies
   ansible.builtin.yum:

--- a/tasks/agent/dependencies/rockylinux/install-rockylinux-dependencies.yml
+++ b/tasks/agent/dependencies/rockylinux/install-rockylinux-dependencies.yml
@@ -11,6 +11,7 @@
   when: ansible_distribution_major_version == "9"
 
 - name: (RockyLinux) Install epel and dkms
+  when: sysdig_agent_driver == "kmodule"
   block:
     - name: Add epel GPG key
       ansible.builtin.rpm_key:
@@ -24,4 +25,3 @@
       ansible.builtin.yum:
         name: dkms
         state: present
-  when: sysdig_agent_driver == "kmodule"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,21 @@
 ---
 - name: Install Sysdig Agent
+  when: install_sysdig_agent
   block:
     - name: Install Dependencies
-      include_tasks: agent/dependencies/{{ ansible_distribution | lower }}/install-{{ ansible_distribution | lower }}-dependencies.yml
+      ansible.builtin.include_tasks: agent/dependencies/{{ ansible_distribution | lower }}/install-{{ ansible_distribution | lower }}-dependencies.yml
       when: sysdig_agent_install_build_dependencies
 
     - name: Configure Sysdig Agent Repository
-      include_tasks: "agent/configure-{{ 'rpm' if ansible_pkg_mgr in ['dnf', 'yum'] else 'deb' }}-repository.yml"
+      ansible.builtin.include_tasks: "agent/configure-{{ 'rpm' if ansible_pkg_mgr in ['dnf', 'yum'] else 'deb' }}-repository.yml"
 
     - name: Install Sysdig Agent
       ansible.builtin.package:
-        name: "draios-agent{% if sysdig_agent_version is defined and sysdig_agent_version %}{% if ansible_pkg_mgr == 'apt' %}={{ sysdig_agent_version }}{% else %}-{{ sysdig_agent_version }}{% endif %}{%endif%}"
-        state: latest
+        name: "draios-agent{% if ansible_pkg_mgr == 'apt' %}={{ sysdig_agent_version }}{% else %}-{{ sysdig_agent_version }}{% endif %}"
+        state: present
 
     - name: Create dragent.yaml file
-      template:
+      ansible.builtin.template:
         src: dragent.yaml.j2
         dest: "/opt/draios/etc/dragent.yaml"
         owner: root
@@ -22,6 +23,7 @@
         mode: 0644
 
     - name: Enable eBPF
+      when: sysdig_agent_driver | lower == "ebpf"
       block:
         - name: (eBPF) Enable eBPF probe
           ansible.builtin.lineinfile:
@@ -29,23 +31,25 @@
             regexp: SYSDIG_BPF_PROBE
             line: export SYSDIG_BPF_PROBE=
             create: true
+            mode: 0o644
 
         - name: (eBPF) Determine if sysdigcloud_probe module is loaded
-          ansible.builtin.shell:
-            cmd: lsmod
-          register: lsmod_res
+          ansible.builtin.command: >
+            lsmod | grep sysdigcloud_probe && echo -n LOADED || echo -n NOT_LOADED
+          register: probe_loaded
+          changed_when: probe_loaded.stdout == 'LOADED'
 
         - name: (eBPF) Stop dragent Service to unload kernel module
           ansible.builtin.service:
             name: dragent
             state: stopped
-          when: lsmod_res.stdout | regex_search('sysdigcloud_probe')
+          when: probe_loaded.stdout == 'LOADED'
 
         - name: (eBPF) Ensure kernel module is not loaded
-          ansible.builtin.shell:
-            cmd: rmmod sysdigcloud_probe
-          when: lsmod_res.stdout | regex_search('sysdigcloud_probe')
-      when: sysdig_agent_driver | lower == "ebpf"
+          ansible.builtin.command: modprobe -r sysdigcloud_probe
+          register: probe_removed
+          when: probe_loaded.stdout == 'LOADED'
+          changed_when: probe_removed.rc == 0
 
     - name: (kmodule) Disable eBPF
       ansible.builtin.lineinfile:
@@ -57,14 +61,13 @@
     - name: Start dragent Service
       block:
         - name: Start dragent Service
-          service:
+          ansible.builtin.service:
             name: dragent
             enabled: true
             state: started
       rescue:
         - name: Attempting to Start dragent Service with sysvinit
-          sysvinit:
+          ansible.builtin.sysvinit:
             name: dragent
             enabled: true
             state: started
-  when: install_sysdig_agent


### PR DESCRIPTION
Bring the tasks in compliance with `ansible-lint` so that we ensure that the upcoming CI workflows will be green.