### PR TITLE
feat: add validations for OS types and version

### DIFF
--- a/tasks/agent/validations/platforms.yml
+++ b/tasks/agent/validations/platforms.yml
@@ -1,0 +1,22 @@
+---
+- name: (Agent) Validate OS Type
+  ansible.builtin.assert:
+    that:
+      - ansible_distribution in supported_platforms
+    quiet: true
+  vars:
+    supported_platforms: ['Amazon', 'CentOS', 'Debian', 'RedHat', 'Rocky', 'Ubuntu']
+
+- name: (Agent) Validate OS Version
+  ansible.builtin.assert:
+    that:
+      - ansible_distribution_version in supported_versions.{{ ansible_distribution | lower }}
+    quiet: true
+  vars:
+    supported_versions:
+      amazon: ['2', '2023']
+      centos: ['7.9', '8', '9']
+      debian: ['10', '11']
+      redhat: ['7', '8', '9']
+      rocky: ['8', '9']
+      ubuntu: ['18.04', '20.04', '22.04']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: Install Sysdig Agent
   when: install_sysdig_agent
   block:
+    - name: Validate Environment
+      ansible.builtin.include_tasks: agent/validations/platforms.yml
+
     - name: Install Dependencies
       ansible.builtin.include_tasks: agent/dependencies/{{ ansible_distribution | lower }}/install-{{ ansible_distribution | lower }}-dependencies.yml
       when: sysdig_agent_install_build_dependencies


### PR DESCRIPTION
Create a mini-support matrix of OS types and their versions that are supported by the Role. Note: The Role supports only a subset of platforms that the Agent supports.