### PR TITLE
fix: signed-by collisions running Role after install-agent script

### DIFF
--- a/tasks/agent/configure-deb-repository.yml
+++ b/tasks/agent/configure-deb-repository.yml
@@ -5,6 +5,14 @@
     dest: /etc/apt/trusted.gpg.d/sysdig.asc
     mode: 0o644
 
-- name: (deb) Configure Sysdig Agent Repository
+- name: (deb) Remove a legacy Sysdig repository configurations
+  ansible.builtin.apt_repository:
+    repo: "deb https://download.sysdig.com/stable/deb stable-$(ARCH)/"
+    filename: draios
+    state: absent
+
+- name: (deb) Configure Sysdig Repository
   ansible.builtin.apt_repository:
     repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/sysdig.asc] https://download.sysdig.com/stable/deb stable-amd64/"
+    filename: sysdig
+    state: present


### PR DESCRIPTION
Running the Role against systems that already had the Agent installed via the legacy `install-agent` script resulted in the following error from apt:
```
Conflicting values set for option Signed-By regarding source https://download.sysdig.com/stable/deb/ stable-amd64/: /etc/apt/trusted.gpg.d/sysdig.asc != , E:The list of sources could not be read.
```
The core of the problem is in two parts.
1) The legacy installation mechanism was not explicitly setting the `signed-by`
   field while the Role was.
2) The Role was not setting a filename for the repository configuration, and
   the `apt_repository` Ansible module was defaulting to
   `download_sysdig_com_stable_deb.list`. This resulted in two files with the
   same Sysdig repo URL defined with two different values for `signed-by`