### PR TITLE
fix: Update feature parsing for app checks and secure_light

### DIFF
--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -131,6 +131,15 @@ argument_specs:
                 type: dict
                 required: false
                 description: "Legacy Sysdig App Check configuration."
+                options:
+                  enabled:
+                    type: bool
+                    required: false
+                    description: "Enable or disable legacy App Checks"
+                  applications:
+                    type: list
+                    required: false
+                    description: "Configurations for App Check modules"
               jmx:
                 type: dict
                 required: false
@@ -164,7 +173,7 @@ argument_specs:
                 type: dict
                 required: false
                 description: "Sysdig Secure Falco Baseliner configuration"
-              memdumper:
+              memdump:
                 type: dict
                 required: false
                 description: "Sysdig Secure Memdumper configuration"


### PR DESCRIPTION
* Add `configuration.security=light` support into the config parser
* Optimize the flow of configuration parsing for both Monitor and Secure
* Re-work the layout of the `features.monitoring.app_checks` block to utilize `enabled` and `applications` fields. This is needed because the app checks are handled differently than the other configurations in the agent in that the `app_checks` key in the agent configuration does not have a nested `enabled` key, but instead leveraged a separate, top level parameter called `app_checks_enabled`.