### PR TITLE
fix: convert memdump to memdumper in various places

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ features:
     captures: ~
     drift_detection: ~
     falcobaseline: ~
-    memdumper: ~
+    memdump: ~
 configuration:
   monitoring: standard
   security: standard

--- a/filter_plugins/dragent.py
+++ b/filter_plugins/dragent.py
@@ -63,8 +63,8 @@ class UserSecureSettings(UserPlanSettings):
         return self._features.get("falcobaseline", {})
 
     @property
-    def memdumper(self) -> dict:
-        return self._features.get("memdumper", {})
+    def memdump(self) -> dict:
+        return self._features.get("memdump", {})
 
 
 class UserConnectionSettings(UserSettings):
@@ -201,7 +201,7 @@ class DragentSecureSettings(DragentSettings):
             ])
 
         res = self._get_config(["commandlines_capture", "drift_detection",
-                                "falcobaseline", "memdumper", "secure_audit_streams"])
+                                "falcobaseline", "memdump", "secure_audit_streams"])
         res.update({feature: {"enabled": False} for feature in disabled_features})
         return res
 

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -176,4 +176,4 @@ argument_specs:
               memdump:
                 type: dict
                 required: false
-                description: "Sysdig Secure Memdumper configuration"
+                description: "Sysdig Secure Memdump configuration"


### PR DESCRIPTION
Remove confusion by sticking with the key name from `dragent.yaml`. This will likely change again in the vars schema to be a more generic term, so for the time being it's less confusing to just stick with the well known key name.