### PR TITLE
ci: update the configure-aws-credentials action to v2

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -60,10 +60,10 @@ jobs:
           SHOW_USAGE: false
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DRAIOS_GH_ACTIONS_ANSIBLE_MOLECULE_ROLE_ARN }}
-          aws-region: us-east-1
+          aws-region: ${{ secrets.REGION }}
 
       - name: Run Molecule tests
         run: |


### PR DESCRIPTION
This resolves a warning about Node.js 12 actions being deprecated