### PR TITLE
feat: remove memdump from vars schema

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,6 @@ features:
     captures: ~
     drift_detection: ~
     falcobaseline: ~
-    memdump: ~
 configuration:
   monitoring: standard
   security: standard

--- a/filter_plugins/dragent.py
+++ b/filter_plugins/dragent.py
@@ -62,10 +62,6 @@ class UserSecureSettings(UserPlanSettings):
     def falcobaseline(self) -> dict:
         return self._features.get("falcobaseline", {})
 
-    @property
-    def memdump(self) -> dict:
-        return self._features.get("memdump", {})
-
 
 class UserConnectionSettings(UserSettings):
     @property
@@ -187,7 +183,6 @@ class DragentSecureSettings(DragentSettings):
                 "drift_control",
                 "drift_killer",
                 "falcobaseline",
-                "memdump",
                 "network_topology",
                 "secure_audit_streams"
             ])
@@ -196,12 +191,11 @@ class DragentSecureSettings(DragentSettings):
                 "drift_control",
                 "drift_killer",
                 "falcobaseline",
-                "memdump",
                 "network_topology"
             ])
 
         res = self._get_config(["commandlines_capture", "drift_detection",
-                                "falcobaseline", "memdump", "secure_audit_streams"])
+                                "falcobaseline", "secure_audit_streams"])
         res.update({feature: {"enabled": False} for feature in disabled_features})
         return res
 

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -173,7 +173,3 @@ argument_specs:
                 type: dict
                 required: false
                 description: "Sysdig Secure Falco Baseliner configuration"
-              memdump:
-                type: dict
-                required: false
-                description: "Sysdig Secure Memdump configuration"


### PR DESCRIPTION
The `memdump` functionality is an internal component that is enabled when needed based on configured policy events.