### PR TITLE
fix: address some epbf bugs

### DIFF
--- a/tasks/agent/dependencies/centos/install-centos-dependencies.yml
+++ b/tasks/agent/dependencies/centos/install-centos-dependencies.yml
@@ -29,6 +29,6 @@
 
 - name: (CentOS) Install eBPF dependencies
   ansible.builtin.yum:
-    name: clang,llvm
+    name: clang,elfutils-libelf-devel,llvm
     state: present
   when: sysdig_agent_driver_type | lower == "ebpf"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,8 @@
             mode: 0o644
 
         - name: (eBPF) Determine if sysdigcloud_probe module is loaded
-          ansible.builtin.command: >
+          ansible.builtin.shell: |
+            set -o pipefail
             lsmod | grep sysdigcloud_probe && echo -n LOADED || echo -n NOT_LOADED
           register: probe_loaded
           changed_when: probe_loaded.stdout == 'LOADED'


### PR DESCRIPTION
* a new ebpf probe build dependency is required on CentOS Stream 8, `elfutils-libelf-devel`
* migrate `ansible.builtin.command` to `ansible.builtin.shell` to properly utilize the `|` operator