### PR TITLE
feat: add exclusions to build_ignore

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -64,4 +64,8 @@ issues: https://github.com/sysdiglabs/agent-ansible-collection/issues
 # uses 'fnmatch' to match the files or directories. Some directories and files like 'galaxy.yml', '*.pyc', '*.retry',
 # and '.git' are always filtered. Mutually exclusive with 'manifest'
 build_ignore:
-  - '.git'
+  - .git
+  - .idea
+  - venv
+  - .yamllint
+


### PR DESCRIPTION
Prevent including of IDE, venv, and yamllint configurations when building the Collection locally.