### PR TITLE
docs: create GitHub auto-release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    labels:
+      - documentation
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features and Improvements 🎉
+      labels:
+        - feature
+        - enhancement
+    - title: Bugfixes 🐛
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Utilize GitHub's ability to automatically generate release notes by providing a configuration. The release notes will be generated by using labels placed on PRs. The labels that are parsed are:
- breaking-change
- feature
- bug
- documentation

PRs tagged with `documentation` will be ignored, but each of the other labels will have their own category in the Release Notes.