### PR TITLE
feat: allow custom package repositories

### DIFF
--- a/plugins/filter/repository.py
+++ b/plugins/filter/repository.py
@@ -1,0 +1,42 @@
+def to_deb_url(data):
+    """ Return the URL to a custom deb repository (if provided) """
+    try:
+        return data['repository']['deb']['url']
+    except KeyError:
+        return ""
+
+
+def to_deb_gpg_key(data):
+    """ Return the URL to the public GPG key for validating the signed deb packages
+    """
+    try:
+        return data['repository']['deb']['gpg_key']
+    except KeyError:
+        return ""
+
+
+def to_rpm_url(data):
+    """ Return the URL to a custom RPM repository (if provided)
+    """
+    try:
+        return data['repository']['rpm']['url']
+    except KeyError:
+        return ""
+
+def to_rpm_gpg_key(data):
+    """ Return the URL to the public GPG key for validating the signed rpm packages
+    """
+    try:
+        return data['repository']['rpm']['gpg_key']
+    except KeyError:
+        return ""
+
+
+class FilterModule:
+    def filters(self):
+        return {
+            "toDebUrl": to_deb_url,
+            "toDebGpgKey": to_deb_gpg_key,
+            "toRpmUrl": to_rpm_url,
+            "toRpmGpgKey": to_rpm_gpg_key
+        }

--- a/roles/agent_install/defaults/main.yml
+++ b/roles/agent_install/defaults/main.yml
@@ -37,3 +37,10 @@ configuration:
       install_build_dependencies: false
     override: ~
     version: 12.14.1
+  repository:
+    deb:
+      url: ~
+      gpg_key: ~
+    rpm:
+      url: ~
+      gpg_key: ~

--- a/roles/agent_install/meta/argument_specs.yml
+++ b/roles/agent_install/meta/argument_specs.yml
@@ -113,6 +113,37 @@ argument_specs:
                 type: str
                 required: false
                 description: "Sysdig Agent version to install"
+          repository:
+            type: dict
+            required: false
+            description: "Custom package repository configuration details"
+            options:
+              rpm:
+                type: dict
+                required: false
+                description: "Custom package repository configuration details for RPMs"
+                options:
+                  url:
+                    type: str
+                    required: true
+                    description: "URL of the custom RPM repository"
+                  gpg_key:
+                    type: str
+                    required: true
+                    description: "URL of the GPG key used to sign the RPM packages"
+              deb:
+                type: dict
+                required: false
+                description: "Custom package repository configuration details for deb packages"
+                options:
+                  url:
+                    type: str
+                    required: true
+                    description: "URL of the custom deb repository"
+                  gpg_key:
+                    type: str
+                    required: true
+                    description: "URL of the GPG key used to sign the deb packages"
       features:
         type: dict
         required: false

--- a/roles/agent_install/tasks/agent/configure-deb-repository.yml
+++ b/roles/agent_install/tasks/agent/configure-deb-repository.yml
@@ -1,7 +1,7 @@
 ---
 - name: (deb) Add Sysdig gpg Key
   ansible.builtin.get_url:
-    url: https://download.sysdig.com/DRAIOS-GPG-KEY.public
+    url: "{{ agent_install_deb_repository_gpgkey }}"
     dest: /etc/apt/trusted.gpg.d/sysdig.asc
     mode: 0o644
 
@@ -13,6 +13,6 @@
 
 - name: (deb) Configure Sysdig Repository
   ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/sysdig.asc] https://download.sysdig.com/stable/deb stable-amd64/"
+    repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/sysdig.asc] {{ agent_install_deb_repository_url }} stable-amd64/"
     filename: sysdig
     state: present

--- a/roles/agent_install/tasks/agent/configure-rpm-repository.yml
+++ b/roles/agent_install/tasks/agent/configure-rpm-repository.yml
@@ -1,7 +1,7 @@
 ---
 - name: (rpm) Configure Sysdig Agent Repository
   ansible.builtin.yum_repository:
-    baseurl: https://download.sysdig.com/stable/rpm/$basearch
+    baseurl: "{{ agent_install_rpm_repository_url }}"
     description: Sysdig Agent Repository
-    gpgkey: https://download.sysdig.com/DRAIOS-GPG-KEY.public
+    gpgkey: "{{ agent_install_rpm_repository_gpgkey }}"
     name: draios

--- a/roles/agent_install/tasks/main.yml
+++ b/roles/agent_install/tasks/main.yml
@@ -4,6 +4,10 @@
     agent_install_version: "{{ configuration | sysdig.agent.toAgentVersion }}"
     agent_install_driver_type: "{{ configuration | sysdig.agent.toAgentDriverType | lower }}"
     agent_install_probe_build_dependencies: "{{ configuration | sysdig.agent.toAgentInstallProbeBuildDependencies | bool }}"
+    agent_install_deb_repository_url: "{{ configuration | sysdig.agent.toDebUrl | default('https://download.sysdig.com/stable/deb', true) }}"
+    agent_install_deb_repository_gpgkey: "{{ configuration | sysdig.agent.toDebGpgKey | default('https://download.sysdig.com/DRAIOS-GPG-KEY.public', true) }}"
+    agent_install_rpm_repository_url: "{{ configuration | sysdig.agent.toRpmUrl | default('https://download.sysdig.com/stable/rpm/$basearch', true) }}"
+    agent_install_rpm_repository_gpgkey: "{{ configuration | sysdig.agent.toRpmGpgKey | default('https://download.sysdig.com/DRAIOS-GPG-KEY.public', true) }}"
 
 - name: Install Sysdig Agent
   block:


### PR DESCRIPTION
Users may wish to store the official packages on a custom repository internal to their environment similar to how users often store the Agent container images on an internal registry. This change allows for that functionality by allowing custom paths for `rpm` and `deb` repository URLs as well as GPG keys.