### PR TITLE
chore: exclude molecule and .github directories from generated Collection

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -65,7 +65,9 @@ issues: https://github.com/sysdiglabs/agent-ansible-collection/issues
 # and '.git' are always filtered. Mutually exclusive with 'manifest'
 build_ignore:
   - .git
+  - .github
   - .idea
+  - molecule
   - venv
   - .yamllint
 


### PR DESCRIPTION
Ensure we do not bundle the CI actions and our test directory (`molecule/`) in our Ansible Collection