### PR TITLE
fix: remove explicit references to amd64 in deb repository configs

### DIFF
--- a/roles/agent_install/tasks/agent/configure-deb-repository.yml
+++ b/roles/agent_install/tasks/agent/configure-deb-repository.yml
@@ -13,6 +13,6 @@
 
 - name: (deb) Configure Sysdig Repository
   ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/sysdig.asc] {{ agent_install_deb_repository_url }} stable-amd64/"
+    repo: "deb [signed-by=/etc/apt/trusted.gpg.d/sysdig.asc] {{ agent_install_deb_repository_url }} stable-$(ARCH)/"
     filename: sysdig
     state: present


### PR DESCRIPTION
The deb package repository configuration had a hardcoded reference to amd64,
which was causing apt to install the incorrect package version on those systems.