### PR TITLE
feat: allow installing the latest version of the agent package

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,1 @@
+roles/agent_install/tasks/main.yml package-latest

--- a/plugins/filter/agent.py
+++ b/plugins/filter/agent.py
@@ -12,7 +12,7 @@ def to_agent_version(data):
     try:
         return data['agent']['version']
     except KeyError:
-        return "12.14.1"
+        return "latest"
 
 
 def to_agent_install_probe_build_dependencies(data):

--- a/roles/agent_install/tasks/main.yml
+++ b/roles/agent_install/tasks/main.yml
@@ -21,10 +21,20 @@
     - name: Configure Sysdig Agent Repository
       ansible.builtin.include_tasks: "agent/configure-{{ 'rpm' if ansible_pkg_mgr in ['dnf', 'yum'] else 'deb' }}-repository.yml"
 
-    - name: Install Sysdig Agent
+    - name: Install Sysdig Agent (latest)
       ansible.builtin.package:
-        name: "draios-agent{% if ansible_pkg_mgr == 'apt' %}={% else %}-{% endif %}{{ agent_install_version }}"
+        name: draios-agent
+        state: latest
+      when: (not agent_install_version) or
+            (agent_install_version and (agent_install_version == 'latest' or agent_install_version == ""))
+
+    - name: Install Sysdig Agent (pinned)
+      ansible.builtin.package:
+        name: "draios-agent{% if agent_install_version != 'latest' %}{% if ansible_pkg_mgr == 'apt' %}={% else %}-{% endif %}{{ agent_install_version }}{% endif %}"
         state: present
+      when:
+        - agent_install_version
+        - agent_install_version != 'latest'
 
     - name: Create dragent.yaml file
       ansible.builtin.template:


### PR DESCRIPTION
The `agent_install` Role had gone out of its way to ensure that it was only possible to install a specific (pinned) version of the Agent. This choice was made to guarantee the idempotence of the Role. This unfortunately ignored the set of users who either want to use the Role to install whatever the latest version of the Agent is at the time, or simply don't mind if the Role is not idempotent.

This change retains the existing behavior of having the version of the Agent be pinned by default, but allows for the installation of the current latest version of the Agent by either specifying an agent version of `latest` or ~.