### PR TITLE
fix: remove 'description' field from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 name: Release
-description: "Release a new version of the Collection"
 on:
   push:
     tags:


### PR DESCRIPTION
schema validation on the GH Action for releasing the Collection indicated that a top level `description` key was needed. Once merged into the repository however, this proved to be an invalid syntax.