### PR TITLE
fix: update permissions.id-token from read to write

### DIFF
--- a/.github/workflows/molecule-ami-update.yml
+++ b/.github/workflows/molecule-ami-update.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: "write"
+  id-token: write
   pull-requests: "write"
 
 jobs:


### PR DESCRIPTION
This fix is necessary for the successful run of the `aws-actions/configure-aws-credentials` action.