### PR TITLE
fix: limit `molecule` test runs to one at a time

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -3,6 +3,8 @@ name: Lint and Test Collection Role Changes
 on:
   - pull_request
 
+concurrency: test-pr
+
 jobs:
   lint-branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
to prevent hitting resource limits in our AWS environments, restrict the number of simultaneous runs of `molecule test` to a single occurrence across all open PRs. this is primarily a safeguard for our auto-update actions that may occasionally open several PRs at the same time, with an absolute worst case scenario of creating several hundred EC2 instances at once.