### PR TITLE
fix: disable centos stream 8 from molecule tests

### DIFF
--- a/molecule/agent-smoke-ebpf/molecule.yml.template
+++ b/molecule/agent-smoke-ebpf/molecule.yml.template
@@ -68,18 +68,18 @@ platforms:
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: centos8-x86
-    boot_wait_seconds: 180
-    image: ami-03dbb661dc3a9b6a5
-    instance_type: ${INSTANCE_TYPE_X86}
-    region: ${REGION}
-    vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: centos8-aarch
-    boot_wait_seconds: 180
-    image: ami-0fbdd12bd5a9c2e6f
-    instance_type: ${INSTANCE_TYPE_AARCH}
-    region: ${REGION}
-    vpc_subnet_id: ${VPC_SUBNET_ID}
+#  - name: centos8-x86
+#    boot_wait_seconds: 180
+#    image: ami-03dbb661dc3a9b6a5
+#    instance_type: ${INSTANCE_TYPE_X86}
+#    region: ${REGION}
+#    vpc_subnet_id: ${VPC_SUBNET_ID}
+#  - name: centos8-aarch
+#    boot_wait_seconds: 180
+#    image: ami-0fbdd12bd5a9c2e6f
+#    instance_type: ${INSTANCE_TYPE_AARCH}
+#    region: ${REGION}
+#    vpc_subnet_id: ${VPC_SUBNET_ID}
   - name: rocky8
     image: ami-0e63078428ec6a2e1
     instance_type: ${INSTANCE_TYPE_X86}

--- a/molecule/agent-smoke-kmodule/molecule.yml.template
+++ b/molecule/agent-smoke-kmodule/molecule.yml.template
@@ -63,18 +63,18 @@ platforms:
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: centos8-x86
-    boot_wait_seconds: 180
-    image: ami-03dbb661dc3a9b6a5
-    instance_type: ${INSTANCE_TYPE_X86}
-    region: ${REGION}
-    vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: centos8-aarch
-    boot_wait_seconds: 180
-    image: ami-0fbdd12bd5a9c2e6f
-    instance_type: ${INSTANCE_TYPE_AARCH}
-    region: ${REGION}
-    vpc_subnet_id: ${VPC_SUBNET_ID}
+#  - name: centos8-x86
+#    boot_wait_seconds: 180
+#    image: ami-03dbb661dc3a9b6a5
+#    instance_type: ${INSTANCE_TYPE_X86}
+#    region: ${REGION}
+#    vpc_subnet_id: ${VPC_SUBNET_ID}
+#  - name: centos8-aarch
+#    boot_wait_seconds: 180
+#    image: ami-0fbdd12bd5a9c2e6f
+#    instance_type: ${INSTANCE_TYPE_AARCH}
+#    region: ${REGION}
+#    vpc_subnet_id: ${VPC_SUBNET_ID}
   - name: rocky8
     image: ami-0e63078428ec6a2e1
     instance_type: ${INSTANCE_TYPE_X86}

--- a/molecule/agent-uninstall-clean-all/molecule.yml.template
+++ b/molecule/agent-uninstall-clean-all/molecule.yml.template
@@ -63,18 +63,18 @@ platforms:
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: centos8-x86
-    boot_wait_seconds: 180
-    image: ami-03dbb661dc3a9b6a5
-    instance_type: ${INSTANCE_TYPE_X86}
-    region: ${REGION}
-    vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: centos8-aarch
-    boot_wait_seconds: 180
-    image: ami-0fbdd12bd5a9c2e6f
-    instance_type: ${INSTANCE_TYPE_AARCH}
-    region: ${REGION}
-    vpc_subnet_id: ${VPC_SUBNET_ID}
+#  - name: centos8-x86
+#    boot_wait_seconds: 180
+#    image: ami-03dbb661dc3a9b6a5
+#    instance_type: ${INSTANCE_TYPE_X86}
+#    region: ${REGION}
+#    vpc_subnet_id: ${VPC_SUBNET_ID}
+#  - name: centos8-aarch
+#    boot_wait_seconds: 180
+#    image: ami-0fbdd12bd5a9c2e6f
+#    instance_type: ${INSTANCE_TYPE_AARCH}
+#    region: ${REGION}
+#    vpc_subnet_id: ${VPC_SUBNET_ID}
   - name: rocky8
     image: ami-0e63078428ec6a2e1
     instance_type: ${INSTANCE_TYPE_X86}


### PR DESCRIPTION
there is currently a known issue with the agent itself and certain versions of the centos stream 8 kernel where the probe will fail to build. this change will be reversed when the issue has been resolved.