### PR TITLE
chore: update Debian 10 (x86_64) images for ebpf tests

### DIFF
--- a/molecule/agent-smoke-ebpf/molecule.yml.template
+++ b/molecule/agent-smoke-ebpf/molecule.yml.template
@@ -24,7 +24,7 @@ platforms:
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
   - name: debian-10
-    image: ami-09c5dc3046df4741f
+    image: ami-041540a5c191757a0
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
@@ -68,18 +68,18 @@ platforms:
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-#  - name: centos8-x86
-#    boot_wait_seconds: 180
-#    image: ami-03dbb661dc3a9b6a5
-#    instance_type: ${INSTANCE_TYPE_X86}
-#    region: ${REGION}
-#    vpc_subnet_id: ${VPC_SUBNET_ID}
-#  - name: centos8-aarch
-#    boot_wait_seconds: 180
-#    image: ami-0fbdd12bd5a9c2e6f
-#    instance_type: ${INSTANCE_TYPE_AARCH}
-#    region: ${REGION}
-#    vpc_subnet_id: ${VPC_SUBNET_ID}
+  #  - name: centos8-x86
+  #    boot_wait_seconds: 180
+  #    image: ami-03dbb661dc3a9b6a5
+  #    instance_type: ${INSTANCE_TYPE_X86}
+  #    region: ${REGION}
+  #    vpc_subnet_id: ${VPC_SUBNET_ID}
+  #  - name: centos8-aarch
+  #    boot_wait_seconds: 180
+  #    image: ami-0fbdd12bd5a9c2e6f
+  #    instance_type: ${INSTANCE_TYPE_AARCH}
+  #    region: ${REGION}
+  #    vpc_subnet_id: ${VPC_SUBNET_ID}
   - name: rocky8
     image: ami-0e63078428ec6a2e1
     instance_type: ${INSTANCE_TYPE_X86}


### PR DESCRIPTION


Update the AMIs used by Molecule to the latest available

---



<Actions>
    <action id="62d0aa1248de491d227bb55c1606b8d6b5e96bc5f1b8b05006d4303618f18002">
        <h3>Molecule AMI updater</h3>
        <details id="e46f8139d0f59b850dd137947773bf5bca18345ae73c27862db10b4ff8f2f23e">
            <summary>Update AMI for Debian 10 (x86_64)</summary>
            <p>key &#34;$.platforms[2].image&#34; updated from &#34;ami-09c5dc3046df4741f&#34; to &#34;ami-041540a5c191757a0&#34;, in file &#34;molecule/agent-smoke-ebpf/molecule.yml.template&#34;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

