### PR TITLE
feat: change the way centos 7 installs epel

### DIFF
--- a/roles/agent_install/tasks/agent/dependencies/centos/install-centos-dependencies.yml
+++ b/roles/agent_install/tasks/agent/dependencies/centos/install-centos-dependencies.yml
@@ -17,10 +17,17 @@
       ansible.builtin.rpm_key:
         key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}
 
-    - name: (CentOS) Install epel
+    - name: (CentOS) Install epel (7)
+      ansible.builtin.yum:
+        name: epel-release
+        state: present
+      when: ansible_distribution_major_version == "7"
+
+    - name: (CentOS) Install epel (8/9)
       ansible.builtin.yum:
         name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
         state: present
+      when: ansible_distribution_major_version != "7"
 
     - name: (CentOS) Install dkms
       ansible.builtin.yum:


### PR DESCRIPTION
due to some infrastructure flakiness with dl.fedoraproject.org where the epel rpm is hosted, the file specific to EL 7 has periodic outages that have caused the `ansible.builtin.yum` module to receive 403 errors and thus fail the installation. the official guidance on epel installation for centos 7 simply says `yum install epel-release`, so this change updates the tasks to match that recommendation and work around this availability issue

source: https://docs.fedoraproject.org/en-US/epel/#_centos_7