### PR TITLE
feat: reduce molecule test times

### DIFF
--- a/molecule/agent-smoke-ebpf/converge.yml.template
+++ b/molecule/agent-smoke-ebpf/converge.yml.template
@@ -1,6 +1,7 @@
 ---
 - name: Converge
   hosts: all
+  strategy: free
   become: true
   roles:
     - role: sysdig.agent.agent_install

--- a/molecule/agent-smoke-kmodule/converge.yml.template
+++ b/molecule/agent-smoke-kmodule/converge.yml.template
@@ -1,6 +1,7 @@
 ---
 - name: Converge
   hosts: all
+  strategy: free
   become: true
   roles:
     - role: sysdig.agent.agent_install

--- a/molecule/agent-uninstall-clean-all/converge.yml.template
+++ b/molecule/agent-uninstall-clean-all/converge.yml.template
@@ -1,6 +1,7 @@
 ---
 - name: Converge
   hosts: all
+  strategy: free
   become: true
   roles:
     - role: sysdig.agent.agent_install

--- a/molecule/resources/playbooks/prepare.yml
+++ b/molecule/resources/playbooks/prepare.yml
@@ -2,6 +2,7 @@
 - name: Prepare
   hosts: all
   gather_facts: true
+  strategy: free
   become: true
   tasks:
     - name: Make sure python3 is installed


### PR DESCRIPTION
by leveraging the `strategy: free` option on the prepare.yml and converge.yml playbooks, we have been able to achieve nearly 40% reductions to test execution times. this will both improve operational and developer efficiencies, as well as help reduce overall cost per test.

**agent-smoke-kmodule**
```
before
real	23m3.128s
user	2m26.588s
sys	0m25.298s

after
real	14m51.880s
user	3m19.322s
sys	0m22.054s
```

**agent-uninstall-clean-all**
```
before
real	23m39.987s
user	2m23.787s
sys	0m26.175s

after
real	14m42.628s
user	3m35.477s
sys	0m23.973s
```