### PR TITLE
chore: migrate to self hosted gh runners

### DIFF
--- a/.github/workflows/molecule-ami-update.yml
+++ b/.github/workflows/molecule-ami-update.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   updatecli:
-    runs-on: "ubuntu-latest"
+    runs-on: tools-runner-small
     strategy:
       matrix:
         platforms:

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   lint-branch:
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
           - agent-smoke-ebpf
           - agent-smoke-kmodule
           - agent-uninstall-clean-all
-    runs-on: ubuntu-latest
+    runs-on: tools-runner
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
migrate all github actions to run on self-hosted runners