### PR TITLE
chore: remove workflow_dispatch event trigger for ami updates

### DIFF
--- a/.github/workflows/molecule-ami-update.yml
+++ b/.github/workflows/molecule-ami-update.yml
@@ -2,7 +2,6 @@
 name: Update Molecule AMIs used for Tests
 
 on:
-  workflow_dispatch:
   schedule:
     # * is a special character in YAML, so you have to quote this string
     # Run once a day


### PR DESCRIPTION
We no longer need to have the ami updates be triggered manually and can just rely on the schedule.