### PR TITLE
chore: SMAGENT-5522 update agent to 12.16.1

### DIFF
--- a/roles/agent_install/defaults/main.yml
+++ b/roles/agent_install/defaults/main.yml
@@ -36,7 +36,7 @@ configuration:
       location: ~
       install_build_dependencies: false
     override: ~
-    version: 12.16.0
+    version: 12.16.1
   repository:
     deb:
       url: ~


### PR DESCRIPTION
## Changes
 - Update agent to version 12.16.1 (see [release notes](https://docs.sysdig.com/en/docs/release-notes/sysdig-agent-release-notes/#12161-september-11-2023))