### PR TITLE
fix: group boto updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/molecule/"
     schedule:
       interval: "daily"
+    groups:
+      aws-boto:
+        patterns:
+          - "boto3"
+          - "botocore"
     labels:
       - "dependencies"
       - "skip-changelog"


### PR DESCRIPTION
ensure dependabot updates boto3 and botocore at the same time so that they are in sync. otherwise, pip will occasionally fail as attempting to update one without the other can break version constraints set by the packages.