### PR TITLE
fix: add retries for epel rpm fetching

### DIFF
--- a/roles/agent_install/tasks/agent/dependencies/almalinux/install-almalinux-dependencies.yml
+++ b/roles/agent_install/tasks/agent/dependencies/almalinux/install-almalinux-dependencies.yml
@@ -16,10 +16,15 @@
     - name: Add epel GPG key
       ansible.builtin.rpm_key:
         key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}
+
     - name: Install epel
       ansible.builtin.yum:
         name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
         state: present
+      retries: 10
+      delay: 3
+      register: result
+      until: result is not failed
 
     - name: Install dkms
       ansible.builtin.yum:

--- a/roles/agent_install/tasks/agent/dependencies/centos/install-centos-dependencies.yml
+++ b/roles/agent_install/tasks/agent/dependencies/centos/install-centos-dependencies.yml
@@ -27,6 +27,10 @@
       ansible.builtin.yum:
         name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
         state: present
+      retries: 10
+      delay: 3
+      register: result
+      until: result is not failed
       when: ansible_distribution_major_version != "7"
 
     - name: (CentOS) Install dkms

--- a/roles/agent_install/tasks/agent/dependencies/redhat/install-redhat-dependencies.yml
+++ b/roles/agent_install/tasks/agent/dependencies/redhat/install-redhat-dependencies.yml
@@ -21,6 +21,10 @@
       ansible.builtin.yum:
         name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
         state: present
+      retries: 10
+      delay: 3
+      register: result
+      until: result is not failed
 
     - name: (RHEL) Install dkms
       ansible.builtin.yum:

--- a/roles/agent_install/tasks/agent/dependencies/rocky/install-rocky-dependencies.yml
+++ b/roles/agent_install/tasks/agent/dependencies/rocky/install-rocky-dependencies.yml
@@ -16,10 +16,15 @@
     - name: Add epel GPG key
       ansible.builtin.rpm_key:
         key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}
+
     - name: Install epel
       ansible.builtin.yum:
         name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
         state: present
+      retries: 10
+      delay: 3
+      register: result
+      until: result is not failed
 
     - name: Install dkms
       ansible.builtin.yum:


### PR DESCRIPTION
due to observed occasional infrastructure flakiness on red hat's side, retry grabbing the epel rpm file a few times before declaring an outright failure.