### PR TITLE
chore: update pinned agent version to 12.17.0

### DIFF
--- a/roles/agent_install/defaults/main.yml
+++ b/roles/agent_install/defaults/main.yml
@@ -36,7 +36,7 @@ configuration:
       location: ~
       install_build_dependencies: false
     override: ~
-    version: 12.16.2
+    version: 12.17.0
   repository:
     deb:
       url: ~


### PR DESCRIPTION
Update the version of the agent that is installed by default to the latest current release (12.17.0)