### PR TITLE
fix: Explicitly install clang and llvm on Ubuntu

### DIFF
--- a/roles/agent_install/tasks/agent/dependencies/ubuntu/install-ubuntu-dependencies.yml
+++ b/roles/agent_install/tasks/agent/dependencies/ubuntu/install-ubuntu-dependencies.yml
@@ -3,3 +3,11 @@
   ansible.builtin.apt:
     name: linux-headers-{{ ansible_kernel }}
     state: present
+
+- name: (Ubuntu) Install clang and llvm
+  ansible.builtin.apt:
+    update_cache: true
+    name:
+      - clang
+      - llvm
+    state: present


### PR DESCRIPTION
Ubuntu 22.04 legacy eBPF tests were failing because clang was not present in the base image by default.