### PR TITLE
chore: cherry-pick galaxy version bump to release branch

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: sysdig
 name: agent
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.0.1
+version: 0.1.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
cherry pick the galaxy version bump to `releases/0.1`