### PR TITLE
fix: ansible-core change prevents certain templating in conditionals

### DIFF
--- a/roles/agent_install/tasks/agent/validations/platforms.yml
+++ b/roles/agent_install/tasks/agent/validations/platforms.yml
@@ -10,7 +10,7 @@
 - name: (Agent) Validate OS Version
   ansible.builtin.assert:
     that:
-      - ansible_distribution_major_version in supported_versions.{{ ansible_distribution | lower }}
+      - ansible_distribution_major_version in supported_versions[ansible_distribution | lower]
     quiet: true
   vars:
     supported_versions:


### PR DESCRIPTION
`ansible-core` introduced a breaking change into a few releases (namely `ansible-core-2.15.7` and `ansible-core-2.16.1`) to address [CVE-2023-5764](https://nvd.nist.gov/vuln/detail/CVE-2023-5764), which involves jinja templating. This change in turn broke some logic in our platform validation task that needed to be updated.