### PR TITLE
feat: modify updatecli ci job to use jsonpath

### DIFF
--- a/.github/updatecli.d/config.yaml.template
+++ b/.github/updatecli.d/config.yaml.template
@@ -19,14 +19,14 @@ actions:
     scmid: "github"
     spec:
       automerge: true
-      description: "Update the AMIs used by Molecule to the latest available"
+      description: "Update the ami reference for ${OS} ${VARIANT} (${ARCHITECTURE}) to the latest available"
       draft: false
       mergemethod: squash
-      title: 'chore: update ${OS} ${ARCHITECTURE} images for ${DRIVER} tests'
+      title: 'chore: update ${OS} ${VARIANT} (${ARCHITECTURE}) image for {{ requiredEnv "SCENARIO_NAME" }} scenario'
 
 sources:
   getAmi:
-    name: Get latest AMI for ${VARIANT}
+    name: Get latest AMI for ${OS} ${VARIANT} (${ARCHITECTURE})
     kind: aws/ami
     spec:
       region: ${REGION}
@@ -39,20 +39,24 @@ sources:
         - name: "owner-id"
           values: "${OWNER_ID}"
 
+conditions:
+  presentInScenario:
+    name: "Check if ${OS} ${VARIANT} (${ARCHITECTURE}) is present in {{ requiredEnv "SCENARIO_NAME" }} scenario"
+    scmid: "github"
+    kind: yaml
+    spec:
+      engine: yamlpath
+      file: {{ requiredEnv "SCENARIO_CONFIG" }}
+      key: $.platforms[?(@.name=="${OS}-${VARIANT}-${ARCHITECTURE}")]
+      keyonly: true
+
 targets:
   updateAmi:
-    name: "Update AMI for ${VARIANT}"
+    name: "Update AMI for ${OS} ${VARIANT} (${ARCHITECTURE}) in {{ requiredEnv "SCENARIO_NAME" }} scenario"
     sourceid: getAmi
     scmid: "github"
     kind: yaml
     spec:
-      files:
-        {{- if eq "${DRIVER}" "legacy_ebpf" }}
-        - molecule/agent-smoke-legacy-ebpf/molecule.yml.template
-        {{- else if eq "${DRIVER}" "universal_ebpf" }}
-        - molecule/agent-smoke-universal-ebpf/molecule.yml.template
-        {{- else if eq "${DRIVER}" "kmod" }}
-        - molecule/agent-smoke-kmodule/molecule.yml.template
-        - molecule/agent-uninstall-clean-all/molecule.yml.template
-        {{- end }}
-      key: "$.platforms[${MOLECULE_INDEX}].image"
+      engine: yamlpath
+      file: {{ requiredEnv "SCENARIO_CONFIG" }}
+      key: $.platforms[?(@.name=="${OS}-${VARIANT}-${ARCHITECTURE}")].image

--- a/.github/workflows/molecule-ami-update.yml
+++ b/.github/workflows/molecule-ami-update.yml
@@ -20,324 +20,100 @@ jobs:
         platforms:
           - os: alma
             architecture: x86_64
-            driver: kmod
             image_name: "AlmaLinux OS 8*"
-            molecule_index: 0
             owner_id: "764336703387"
             task_name: Alma8-x86_64
-            variant: "Alma 8 (x86_64)"
+            variant: "8"
           - os: alma
             architecture: x86_64
-            driver: legacy_ebpf
-            image_name: "AlmaLinux OS 8*"
-            molecule_index: 0
-            owner_id: "764336703387"
-            task_name: Alma8-x86_64
-            variant: "Alma 8 (x86_64)"
-          - os: alma
-            architecture: x86_64
-            driver: universal_ebpf
-            image_name: "AlmaLinux OS 8*"
-            molecule_index: 0
-            owner_id: "764336703387"
-            task_name: Alma8-x86_64
-            variant: "Alma 8 (x86_64)"
-          - os: alma
-            architecture: x86_64
-            driver: kmod
             image_name: "AlmaLinux OS 9*"
-            molecule_index: 1
             owner_id: "764336703387"
             task_name: Alma9-x86_64
-            variant: "Alma 9 (x86_64)"
-          - os: alma
-            architecture: x86_64
-            driver: legacy_ebpf
-            image_name: "AlmaLinux OS 9*"
-            molecule_index: 1
-            owner_id: "764336703387"
-            task_name: Alma9-x86_64
-            variant: "Alma 9 (x86_64)"
-          - os: alma
-            architecture: x86_64
-            driver: universal_ebpf
-            image_name: "AlmaLinux OS 9*"
-            molecule_index: 1
-            owner_id: "764336703387"
-            task_name: Alma9-x86_64
-            variant: "Alma 9 (x86_64)"
+            variant: "9"
           - os: amazon
             architecture: x86_64
-            driver: kmod
             image_name: amzn2*
-            molecule_index: 9
             owner_id: "137112412989"
             task_name: Amzn2-x86_64
-            variant: "Amazon Linux 2 (x86_64)"
+            variant: "2"
           - os: amazon
             architecture: x86_64
-            driver: legacy_ebpf
-            image_name: amzn2*
-            molecule_index: 9
-            owner_id: "137112412989"
-            task_name: Amzn2-x86_64
-            variant: "Amazon Linux 2 (x86_64)"
-          - os: amazon
-            architecture: x86_64
-            driver: kmod
             image_name: al2023-ami*
-            molecule_index: 10
             owner_id: "137112412989"
             task_name: AL2023-x86_64
-            variant: "Amazon Linux 2023 (x86_64)"
-          - os: amazon
-            architecture: x86_64
-            driver: legacy_ebpf
-            image_name: al2023-ami*
-            molecule_index: 10
-            owner_id: "137112412989"
-            task_name: AL2023-x86_64
-            variant: "Amazon Linux 2023 (x86_64)"
-          - os: amazon
-            architecture: x86_64
-            driver: universal_ebpf
-            image_name: al2023-ami*
-            molecule_index: 7
-            owner_id: "137112412989"
-            task_name: AL2023-x86_64
-            variant: "Amazon Linux 2023 (x86_64)"
+            variant: "2023"
           - os: centos
             architecture: x86_64
-            driver: kmod
             image_name: "CentOS Linux 7 x86_64*"
-            molecule_index: 13
             owner_id: "125523088429"
             task_name: CentOS7-x86_64
-            variant: "CentOS 7 (x86_64)"
-#          - os: centos
-#            architecture: x86_64
-#            driver: kmod
-#            image_name: "CentOS Stream 8 x86_64*"
-#            molecule_index: 11
-#            owner_id: "125523088429"
-#            task_name: CentOS8-x86_64
-#            variant: "CentOS Stream 8 (x86_64)"
-#          - os: centos
-#            architecture: x86_64
-#            driver: legacy_ebpf
-#            image_name: "CentOS Stream 8 x86_64*"
-#            molecule_index: 11
-#            owner_id: "125523088429"
-#            task_name: CentOS8-x86_64
-#            variant: "CentOS Stream 8 (x86_64)"
-#          - os: centos
-#            architecture: arm64
-#            driver: kmod
-#            image_name: "CentOS Stream 8 aarch64*"
-#            molecule_index: 12
-#            owner_id: "125523088429"
-#            task_name: CentOS8-arm64
-#            variant: "CentOS Stream 8 (arm64)"
-#          - os: centos
-#            architecture: arm64
-#            driver: legacy_ebpf
-#            image_name: "CentOS Stream 8 aarch64*"
-#            molecule_index: 12
-#            owner_id: "125523088429"
-#            task_name: CentOS8-arm64
-#            variant: "CentOS Stream 8 (arm64)"
+            variant: "7"
+          - os: centos
+            architecture: x86_64
+            image_name: "CentOS Stream 8 x86_64*"
+            owner_id: "125523088429"
+            task_name: CentOS8-x86_64
+            variant: "8"
+          - os: centos
+            architecture: arm64
+            image_name: "CentOS Stream 8 aarch64*"
+            owner_id: "125523088429"
+            task_name: CentOS8-arm64
+            variant: "8"
           - os: debian
             architecture: x86_64
-            driver: kmod
             image_name: "debian-10-amd64*"
-            molecule_index: 2
             owner_id: "136693071363"
             task_name: Debian10-x86_64
-            variant: "Debian 10 (x86_64)"
+            variant: "10"
           - os: debian
             architecture: x86_64
-            driver: legacy_ebpf
-            image_name: "debian-10-amd64*"
-            molecule_index: 2
-            owner_id: "136693071363"
-            task_name: Debian10-x86_64
-            variant: "Debian 10 (x86_64)"
-          - os: debian
-            architecture: x86_64
-            driver: kmod
             image_name: "debian-11-amd64*"
-            molecule_index: 3
             owner_id: "136693071363"
             task_name: Debian11-x86_64
-            variant: "Debian 11 (x86_64)"
+            variant: "11"
           - os: debian
             architecture: x86_64
-            driver: legacy_ebpf
-            image_name: "debian-11-amd64*"
-            molecule_index: 3
-            owner_id: "136693071363"
-            task_name: Debian11-x86_64
-            variant: "Debian 11 (x86_64)"
-          - os: debian
-            architecture: x86_64
-            driver: universal_ebpf
-            image_name: "debian-11-amd64*"
-            molecule_index: 2
-            owner_id: "136693071363"
-            task_name: Debian11-x86_64
-            variant: "Debian 11 (x86_64)"
-          - os: debian
-            architecture: x86_64
-            driver: kmod
             image_name: "debian-12-amd64*"
-            molecule_index: 4
             owner_id: "136693071363"
             task_name: Debian12-x86_64
-            variant: "Debian 12 (x86_64)"
-          - os: debian
-            architecture: x86_64
-            driver: legacy_ebpf
-            image_name: "debian-12-amd64*"
-            molecule_index: 4
-            owner_id: "136693071363"
-            task_name: Debian12-x86_64
-            variant: "Debian 12 (x86_64)"
-          - os: debian
-            architecture: x86_64
-            driver: universal_ebpf
-            image_name: "debian-12-amd64*"
-            molecule_index: 3
-            owner_id: "136693071363"
-            task_name: Debian12-x86_64
-            variant: "Debian 12 (x86_64)"
+            variant: "12"
           - os: rocky
             architecture: x86_64
-            driver: kmod
             image_name: "Rocky-8-EC2-Base*"
-            molecule_index: 11
             owner_id: "792107900819"
             task_name: Rocky8-x86_64
-            variant: "Rocky 8 (x86_64)"
+            variant: "8"
           - os: rocky
             architecture: x86_64
-            driver: legacy_ebpf
-            image_name: "Rocky-8-EC2-Base*"
-            molecule_index: 11
-            owner_id: "792107900819"
-            task_name: Rocky8-x86_64
-            variant: "Rocky 8 (x86_64)"
-          - os: rocky
-            architecture: x86_64
-            driver: kmod
             image_name: "Rocky-9-EC2-Base*"
-            molecule_index: 12
             owner_id: "792107900819"
             task_name: Rocky9-x86_64
-            variant: "Rocky 9 (x86_64)"
-          - os: rocky
-            architecture: x86_64
-            driver: legacy_ebpf
-            image_name: "Rocky-9-EC2-Base*"
-            molecule_index: 12
-            owner_id: "792107900819"
-            task_name: Rocky9-x86_64
-            variant: "Rocky 9 (x86_64)"
-          - os: rocky
-            architecture: x86_64
-            driver: universal_ebpf
-            image_name: "Rocky-9-EC2-Base*"
-            molecule_index: 8
-            owner_id: "792107900819"
-            task_name: Rocky9-x86_64
-            variant: "Rocky 9 (x86_64)"
+            variant: "9"
           - os: ubuntu
             architecture: x86_64
-            driver: kmod
             image_name: ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server*
-            molecule_index: 5
             owner_id: "099720109477"
             task_name: Ubuntu1804-x86_64
-            variant: "Ubuntu 18.04 (x86_64)"
+            variant: "1804"
           - os: ubuntu
             architecture: x86_64
-            driver: legacy_ebpf
-            image_name: ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server*
-            molecule_index: 5
-            owner_id: "099720109477"
-            task_name: Ubuntu1804-x86_64
-            variant: "Ubuntu 18.04 (x86_64)"
-          - os: ubuntu
-            architecture: x86_64
-            driver: kmod
             image_name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server*
-            molecule_index: 6
             owner_id: "099720109477"
             task_name: Ubuntu2004-x86_64
-            variant: "Ubuntu 20.04 (x86_64)"
+            variant: "2004"
           - os: ubuntu
             architecture: x86_64
-            driver: legacy_ebpf
-            image_name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server*
-            molecule_index: 6
-            owner_id: "099720109477"
-            task_name: Ubuntu2004-x86_64
-            variant: "Ubuntu 20.04 (x86_64)"
-          - os: ubuntu
-            architecture: x86_64
-            driver: universal_ebpf
-            image_name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server*
-            molecule_index: 4
-            owner_id: "099720109477"
-            task_name: Ubuntu2004-x86_64
-            variant: "Ubuntu 20.04 (x86_64)"
-          - os: ubuntu
-            architecture: x86_64
-            driver: kmod
             image_name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server*
-            molecule_index: 7
             owner_id: "099720109477"
             task_name: Ubuntu2204-x86_64
-            variant: "Ubuntu 22.04 (x86_64)"
-          - os: ubuntu
-            architecture: x86_64
-            driver: legacy_ebpf
-            image_name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server*
-            molecule_index: 7
-            owner_id: "099720109477"
-            task_name: Ubuntu2204-x86_64
-            variant: "Ubuntu 22.04 (x86_64)"
-          - os: ubuntu
-            architecture: x86_64
-            driver: universal_ebpf
-            image_name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server*
-            molecule_index: 5
-            owner_id: "099720109477"
-            task_name: Ubuntu2204-x86_64
-            variant: "Ubuntu 22.04 (x86_64)"
+            variant: "2204"
           - os: ubuntu
             architecture: arm64
-            driver: kmod
             image_name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server*
-            molecule_index: 8
             owner_id: "099720109477"
             task_name: Ubuntu2204-arm64
-            variant: "Ubuntu 22.04 (arm64)"
-          - os: ubuntu
-            architecture: arm64
-            driver: legacy_ebpf
-            image_name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server*
-            molecule_index: 8
-            owner_id: "099720109477"
-            task_name: Ubuntu2204-arm64
-            variant: "Ubuntu 22.04 (arm64)"
-          - os: ubuntu
-            architecture: arm64
-            driver: universal_ebpf
-            image_name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server*
-            molecule_index: 6
-            owner_id: "099720109477"
-            task_name: Ubuntu2204-arm64
-            variant: "Ubuntu 22.04 (arm64)"
+            variant: "2204"
 
     steps:
       - name: Checkout
@@ -354,7 +130,7 @@ jobs:
 
       - name: Substitute matrix vars
         run: |
-          cat .github/updatecli.d/config.yaml.template | envsubst > .github/updatecli.d/config-${{ matrix.platforms.driver }}-${{ matrix.platforms.task_name }}.yaml
+          cat .github/updatecli.d/config.yaml.template | envsubst > .github/updatecli.d/config-${{ matrix.platforms.task_name }}.yaml
         env:
           TASK_NAME: ${{ matrix.platforms.task_name }}
           VARIANT: ${{ matrix.platforms.variant }}
@@ -362,11 +138,16 @@ jobs:
           OS: ${{ matrix.platforms.os }}
           ARCHITECTURE: ${{ matrix.platforms.architecture }}
           OWNER_ID: ${{ matrix.platforms.owner_id }}
-          MOLECULE_INDEX: ${{ matrix.platforms.molecule_index }}
           IMAGE_NAME: ${{ matrix.platforms.image_name }}
-          DRIVER: ${{ matrix.platforms.driver }}
 
-      - name: Run Updatecli in apply mode
-        run: "updatecli apply --config .github/updatecli.d/config-${{ matrix.platforms.driver }}-${{ matrix.platforms.task_name }}.yaml"
+      - name: Run updatecli in apply mode
+        run: |
+          for scenario in $(find . -name "molecule.yml.template" -type f | sed 's/^.\///g');
+          do
+            scenario_name=$(basename $(dirname $scenario))
+            export SCENARIO_CONFIG=$scenario
+            export SCENARIO_NAME=$scenario_name
+            updatecli apply --config .github/updatecli.d/config-${{ matrix.platforms.task_name }}.yaml
+          done
         env:
           GITHUB_TOKEN: "${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}"

--- a/.github/workflows/molecule-ami-update.yml
+++ b/.github/workflows/molecule-ami-update.yml
@@ -22,97 +22,81 @@ jobs:
             architecture: x86_64
             image_name: "AlmaLinux OS 8*"
             owner_id: "764336703387"
-            task_name: Alma8-x86_64
             variant: "8"
           - os: alma
             architecture: x86_64
             image_name: "AlmaLinux OS 9*"
             owner_id: "764336703387"
-            task_name: Alma9-x86_64
             variant: "9"
           - os: amazon
             architecture: x86_64
             image_name: amzn2*
             owner_id: "137112412989"
-            task_name: Amzn2-x86_64
             variant: "2"
           - os: amazon
             architecture: x86_64
             image_name: al2023-ami*
             owner_id: "137112412989"
-            task_name: AL2023-x86_64
             variant: "2023"
           - os: centos
             architecture: x86_64
             image_name: "CentOS Linux 7 x86_64*"
             owner_id: "125523088429"
-            task_name: CentOS7-x86_64
             variant: "7"
           - os: centos
             architecture: x86_64
             image_name: "CentOS Stream 8 x86_64*"
             owner_id: "125523088429"
-            task_name: CentOS8-x86_64
             variant: "8"
           - os: centos
             architecture: arm64
             image_name: "CentOS Stream 8 aarch64*"
             owner_id: "125523088429"
-            task_name: CentOS8-arm64
             variant: "8"
           - os: debian
             architecture: x86_64
             image_name: "debian-10-amd64*"
             owner_id: "136693071363"
-            task_name: Debian10-x86_64
             variant: "10"
           - os: debian
             architecture: x86_64
             image_name: "debian-11-amd64*"
             owner_id: "136693071363"
-            task_name: Debian11-x86_64
             variant: "11"
           - os: debian
             architecture: x86_64
             image_name: "debian-12-amd64*"
             owner_id: "136693071363"
-            task_name: Debian12-x86_64
             variant: "12"
           - os: rocky
             architecture: x86_64
             image_name: "Rocky-8-EC2-Base*"
             owner_id: "792107900819"
-            task_name: Rocky8-x86_64
             variant: "8"
           - os: rocky
             architecture: x86_64
             image_name: "Rocky-9-EC2-Base*"
             owner_id: "792107900819"
-            task_name: Rocky9-x86_64
             variant: "9"
           - os: ubuntu
             architecture: x86_64
             image_name: ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server*
             owner_id: "099720109477"
-            task_name: Ubuntu1804-x86_64
             variant: "1804"
           - os: ubuntu
             architecture: x86_64
             image_name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server*
             owner_id: "099720109477"
-            task_name: Ubuntu2004-x86_64
             variant: "2004"
           - os: ubuntu
             architecture: x86_64
             image_name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server*
             owner_id: "099720109477"
-            task_name: Ubuntu2204-x86_64
             variant: "2204"
           - os: ubuntu
             architecture: arm64
             image_name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server*
             owner_id: "099720109477"
-            task_name: Ubuntu2204-arm64
             variant: "2204"
 
     steps:
@@ -130,9 +114,8 @@ jobs:
 
       - name: Substitute matrix vars
         run: |
-          cat .github/updatecli.d/config.yaml.template | envsubst > .github/updatecli.d/config-${{ matrix.platforms.task_name }}.yaml
+          cat .github/updatecli.d/config.yaml.template | envsubst > .github/updatecli.d/config-${{ matrix.platforms.os }}-${{ matrix.platforms.variant }}-${{ matrix.platforms.architecture }}.yaml
         env:
-          TASK_NAME: ${{ matrix.platforms.task_name }}
           VARIANT: ${{ matrix.platforms.variant }}
           REGION: ${{ secrets.REGION }}
           OS: ${{ matrix.platforms.os }}
@@ -147,7 +130,7 @@ jobs:
             scenario_name=$(basename $(dirname $scenario))
             export SCENARIO_CONFIG=$scenario
             export SCENARIO_NAME=$scenario_name
-            updatecli apply --config .github/updatecli.d/config-${{ matrix.platforms.task_name }}.yaml
+            updatecli apply --config .github/updatecli.d/config-${{ matrix.platforms.os }}-${{ matrix.platforms.variant }}-${{ matrix.platforms.architecture }}.yaml
           done
         env:
           GITHUB_TOKEN: "${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}"

--- a/molecule/agent-smoke-kmodule/molecule.yml.template
+++ b/molecule/agent-smoke-kmodule/molecule.yml.template
@@ -8,52 +8,52 @@ lint: |
   ansible-lint tasks/agent
   yamllint tasks/agent
 platforms:
-  - name: alma8
+  - name: alma-8-x86_64
     image: ami-0ebb096e453d2fb20
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: alma9
+  - name: alma-9-x86_64
     image: ami-0b1e78fb6f0d36eb3
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: debian-10
+  - name: debian-10-x86_64
     image: ami-0770134595d82d48f
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: debian-11
+  - name: debian-11-x86_64
     image: ami-0133fb3dded749b65
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: debian-12
+  - name: debian-12-x86_64
     image: ami-058bd2d568351da34
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-1804
+  - name: ubuntu-1804-x86_64
     image: ami-055744c75048d8296
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-2004
+  - name: ubuntu-2004-x86_64
     image: ami-06aa3f7caf3a30282
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-2204-x86
+  - name: ubuntu-2204-x86_64
     image: ami-0e783882a19958fff
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-2204-aarch
+  - name: ubuntu-2204-arm64
     image: ami-01ec7354bd709968b
     instance_type: ${INSTANCE_TYPE_AARCH}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: amzn2
+  - name: amazon-2-x86_64
     image: ami-03bd01bf2139c515c
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
@@ -63,7 +63,7 @@ platforms:
         ebs:
           volume_size: 5
           delete_on_termination: true
-  - name: al2023
+  - name: amazon-2023-x86_64
     image: ami-0d4df6583e939a1c4
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
@@ -85,12 +85,12 @@ platforms:
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: rocky9
+  - name: rocky-9-x86_64
     image: ami-07d75f492ac3a326f
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: centos7
+  - name: centos-7-x86_64
     image: ami-0aedf6b1cb669b4c7
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}

--- a/molecule/agent-smoke-legacy-ebpf/molecule.yml.template
+++ b/molecule/agent-smoke-legacy-ebpf/molecule.yml.template
@@ -8,7 +8,7 @@ lint: |
   ansible-lint tasks/agent
   yamllint tasks/agent
 platforms:
-  - name: alma8
+  - name: alma-8-x86_64
     image: ami-017cf0c1f7146f117
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
@@ -18,47 +18,47 @@ platforms:
         ebs:
           volume_size: 30
           delete_on_termination: true
-  - name: alma9
+  - name: alma-9-x86_64
     image: ami-0b1e78fb6f0d36eb3
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: debian-10
+  - name: debian-10-x86_64
     image: ami-0770134595d82d48f
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: debian-11
+  - name: debian-11-x86_64
     image: ami-0133fb3dded749b65
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: debian-12
+  - name: debian-12-x86_64
     image: ami-058bd2d568351da34
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-1804
+  - name: ubuntu-1804-x86_64
     image: ami-055744c75048d8296
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-2004
+  - name: ubuntu-2004-x86_64
     image: ami-04b107e90218672e5
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-2204-x86
+  - name: ubuntu-2204-x86_64
     image: ami-008d819eefb4b5ee4
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-2204-aarch
+  - name: ubuntu-2204-amd64
     image: ami-01ec7354bd709968b
     instance_type: ${INSTANCE_TYPE_AARCH}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: amzn2
+  - name: amazon-2-x86_64
     image: ami-0874a928bbdd99fbc
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
@@ -68,7 +68,7 @@ platforms:
         ebs:
           volume_size: 5
           delete_on_termination: true
-  - name: al2023
+  - name: amazon-2023-x86_64
     image: ami-0d4df6583e939a1c4
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
@@ -90,7 +90,7 @@ platforms:
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: rocky9
+  - name: rocky-9-x86_64
     image: ami-07d75f492ac3a326f
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}

--- a/molecule/agent-smoke-universal-ebpf/molecule.yml.template
+++ b/molecule/agent-smoke-universal-ebpf/molecule.yml.template
@@ -8,7 +8,7 @@ lint: |
   ansible-lint tasks/agent
   yamllint tasks/agent
 platforms:
-  - name: alma8
+  - name: alma-8-x86_64
     image: ami-017cf0c1f7146f117
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
@@ -18,42 +18,42 @@ platforms:
         ebs:
           volume_size: 30
           delete_on_termination: true
-  - name: alma9
+  - name: alma-9-x86_64
     image: ami-0b1e78fb6f0d36eb3
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: debian-11
+  - name: debian-11-x86_64
     image: ami-0133fb3dded749b65
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: debian-12
+  - name: debian-12-x86_64
     image: ami-058bd2d568351da34
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-2004
+  - name: ubuntu-2004-x86_64
     image: ami-04b107e90218672e5
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-2204-x86
+  - name: ubuntu-2204-x86_64
     image: ami-0e783882a19958fff
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-2204-aarch
+  - name: ubuntu-2204-arm64
     image: ami-0feba2720136a0493
     instance_type: ${INSTANCE_TYPE_AARCH}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: al2023
+  - name: amazon-2023-x86_64
     image: ami-0f2eb5749e5a5699e
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: rocky9
+  - name: rocky-9-x86_64
     image: ami-07d75f492ac3a326f
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}

--- a/molecule/agent-uninstall-clean-all/molecule.yml.template
+++ b/molecule/agent-uninstall-clean-all/molecule.yml.template
@@ -8,52 +8,52 @@ lint: |
   ansible-lint tasks/agent
   yamllint tasks/agent
 platforms:
-  - name: alma8
+  - name: alma-8-x86_64
     image: ami-0ebb096e453d2fb20
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: alma9
+  - name: alma-9-x86_64
     image: ami-0b1e78fb6f0d36eb3
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: debian-10
+  - name: debian-10-x86_64
     image: ami-0770134595d82d48f
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: debian-11
+  - name: debian-11-x86_64
     image: ami-0133fb3dded749b65
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: debian-12
+  - name: debian-12-x86_64
     image: ami-058bd2d568351da34
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-1804
+  - name: ubuntu-1804-x86_64
     image: ami-055744c75048d8296
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-2004
+  - name: ubuntu-2004-x86_64
     image: ami-06aa3f7caf3a30282
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-2204-x86
+  - name: ubuntu-2204-x86_64
     image: ami-0e783882a19958fff
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: ubuntu-2204-aarch
+  - name: ubuntu-2204-arm64
     image: ami-01ec7354bd709968b
     instance_type: ${INSTANCE_TYPE_AARCH}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: amzn2
+  - name: amazon-2-x86_64
     image: ami-03bd01bf2139c515c
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
@@ -63,7 +63,7 @@ platforms:
         ebs:
           volume_size: 5
           delete_on_termination: true
-  - name: al2023
+  - name: amazon-2023-x86_64
     image: ami-0d4df6583e939a1c4
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
@@ -85,12 +85,12 @@ platforms:
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: rocky9
+  - name: rocky-9-x86_64
     image: ami-07d75f492ac3a326f
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}
     vpc_subnet_id: ${VPC_SUBNET_ID}
-  - name: centos7
+  - name: centos-7-x86_64
     image: ami-0aedf6b1cb669b4c7
     instance_type: ${INSTANCE_TYPE_X86}
     region: ${REGION}


### PR DESCRIPTION
`updatecli` now supports jsonpath. this allows us to simplify the update process for the test amis. this process used to be based on hardcoded indexes into the yaml list containing their definitions, but that process was both error prone and did not provide an easy way to support test scenarios with variable number of test amis.