### PR TITLE
fix: add pipelineid to avoid clash in image updates

### DIFF
--- a/.github/updatecli.d/config.yaml.template
+++ b/.github/updatecli.d/config.yaml.template
@@ -1,5 +1,6 @@
 # config.yaml
 name: Molecule AMI updater
+pipelineid: ${OS}-${VARIANT}-${ARCHITECTURE}
 
 scms:
   github:


### PR DESCRIPTION
See https://github.com/updatecli/updatecli/blob/bf6ad3ec6a8a5e9dca99501af662b640460ab47a/pkg/core/config/main.go#L62-L74