### PR TITLE
Release agent 12.20.0 and 0.3 release prep

### DIFF
--- a/roles/agent_install/defaults/main.yml
+++ b/roles/agent_install/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for ansible-sysdig
-role_version: 0.0.1
+role_version: 0.3.0
 
 features:
   monitoring:

--- a/roles/agent_install/defaults/main.yml
+++ b/roles/agent_install/defaults/main.yml
@@ -37,7 +37,7 @@ configuration:
       location: null
       install_build_dependencies: false
     override: null
-    version: 12.19.0
+    version: 12.20.0
   repository:
     deb:
       url: null


### PR DESCRIPTION
## Changes
 - bump default version for Linux Agent to 12.20.0
 - prepare for the 0.3.0 release