### PR TITLE
chore: prepare for the 0.4.1 release

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: sysdig
 name: agent
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.4.0
+version: 0.4.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/agent_install/defaults/main.yml
+++ b/roles/agent_install/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for ansible-sysdig
-role_version: 0.4.0
+role_version: 0.4.1
 
 features:
   monitoring:


### PR DESCRIPTION
Bump versions as preparation for the release.