### PR TITLE
fix(ebpf): robustify probe unloading in case of ebpf

### DIFF
--- a/roles/agent_install/tasks/main.yml
+++ b/roles/agent_install/tasks/main.yml
@@ -80,10 +80,19 @@
             state: stopped
           when: agent_install_probe_loaded.stdout == 'LOADED'
 
+        - name: (eBPF) Determine if sysdigcloud_probe module is still loaded after stop
+          ansible.builtin.shell:
+            cmd: |
+              set -o pipefail
+              lsmod | grep -q sysdigcloud_probe && echo -n LOADED || echo -n NOT_LOADED
+            executable: bash
+          register: agent_install_probe_loaded_after_stop
+          changed_when: agent_install_probe_loaded_after_stop.stdout == 'LOADED'
+
         - name: (eBPF) Ensure kernel module is not loaded
-          ansible.builtin.command: modprobe -r sysdigcloud_probe
+          ansible.builtin.command: modprobe -r sysdigcloud_probe || rmmod sysdigcloud_probe
           register: agent_install_probe_removed
-          when: agent_install_probe_loaded.stdout == 'LOADED'
+          when: agent_install_probe_loaded_after_stop.stdout == 'LOADED'
           changed_when: agent_install_probe_removed.rc == 0
 
     - name: (kmod) Disable eBPF

--- a/roles/agent_install/tasks/main.yml
+++ b/roles/agent_install/tasks/main.yml
@@ -90,7 +90,10 @@
           changed_when: agent_install_probe_loaded_after_stop.stdout == 'LOADED'
 
         - name: (eBPF) Ensure kernel module is not loaded
-          ansible.builtin.command: modprobe -r sysdigcloud_probe || rmmod sysdigcloud_probe
+          ansible.builtin.shell:
+            cmd: |
+              modprobe -r sysdigcloud_probe || rmmod sysdigcloud_probe
+            executable: bash
           register: agent_install_probe_removed
           when: agent_install_probe_loaded_after_stop.stdout == 'LOADED'
           changed_when: agent_install_probe_removed.rc == 0


### PR DESCRIPTION
there might be situations which we have a
downloaded kernel module loaded in the system.
In that case, modprobe -r will fail since the module is not known to the system.
Also, the service unit should normally remove
it autonomously, so the explicit removal should
only be taken as the last resort.

So put in place the two following changes:
1. After stopping the unit, check if the module is still present -- do nothing if not
2. Try with modprobe -r first and if that fails, try with rmmod