### PR TITLE
fix(molecule, debian): workaround for debian10 buster-backports

### DIFF
--- a/molecule/resources/playbooks/prepare.yml
+++ b/molecule/resources/playbooks/prepare.yml
@@ -12,7 +12,7 @@
 
     - name: Prepare Debian hosts
       block:
-        - name: Replace buster-backports
+        - name: Work around buster-backports (debian 10)
           ansible.builtin.replace:
             path: /etc/apt/sources.list
             regexp: '(^.*http://).*(\.debian\.org.*buster-backports.*$)'

--- a/molecule/resources/playbooks/prepare.yml
+++ b/molecule/resources/playbooks/prepare.yml
@@ -17,6 +17,7 @@
             path: /etc/apt/sources.list
             regexp: '(^.*http://).*(\.debian\.org.*buster-backports.*$)'
             replace: '\1archive\2'
+          when: ansible_distribution_major_version == "10"
 
         - name: Update apt cache
           ansible.builtin.apt:

--- a/molecule/resources/playbooks/prepare.yml
+++ b/molecule/resources/playbooks/prepare.yml
@@ -12,6 +12,12 @@
 
     - name: Prepare Debian hosts
       block:
+        - name: Replace buster-backports
+          ansible.builtin.replace:
+            path: /etc/apt/sources.list
+            regexp: '(^.*http://).*(\.debian\.org.*buster-backports.*$)'
+            replace: '\1archive\2'
+
         - name: Update apt cache
           ansible.builtin.apt:
             update_cache: true


### PR DESCRIPTION
apparently debian-backports has been archived from live debian repositories, leading to the following error messages:

  fatal: [debian-10-x86_64]: FAILED! => {"changed": false, "msg": "Failed to update apt cache: W:Updating from such a repository can't be done securely, and is therefore disabled by default., W:See apt-secure(8) manpage for repository creation and user configuration details., E:The repository 'http://cdn-aws.deb.debian.org/debian buster-backports Release' does not have a Release file."}

As suggested by [1], work around that issue by patching the repository URL so to use debian archives instead.

[1] https://www.cyberciti.biz/faq/the-repository-http-deb-debian-org-debian-buster-backports-release-no-longer-has-a-release-file/