### PR TITLE
Install EL8 / Amazon Linux dependencies via package-manager CLI

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,1 +1,3 @@
 roles/agent_install/tasks/main.yml package-latest
+roles/agent_install/tasks/agent/dependencies/redhat/install-redhat-dependencies.yml command-instead-of-module
+roles/agent_install/tasks/agent/dependencies/amazon/install-amazon-dependencies.yml command-instead-of-module

--- a/roles/agent_install/tasks/agent/dependencies/amazon/install-amazon-dependencies.yml
+++ b/roles/agent_install/tasks/agent/dependencies/amazon/install-amazon-dependencies.yml
@@ -1,17 +1,17 @@
 ---
 - name: (Amazon Linux) Install Kernel Headers
-  ansible.builtin.yum:
-    name: kernel-devel-{{ ansible_kernel }}
-    state: present
+  ansible.builtin.command: yum -y install "kernel-devel-{{ ansible_kernel }}"
+  args:
+    creates: /usr/src/kernels/{{ ansible_kernel }}
 
 - name: (Amazon Linux) Install dkms
-  ansible.builtin.yum:
-    name: dkms
-    state: present
+  ansible.builtin.command: yum -y install dkms
+  args:
+    creates: /usr/sbin/dkms
   when: agent_install_driver_type == "kmod"
 
 - name: (Amazon Linux) Install chkconfig
-  ansible.builtin.yum:
-    name: chkconfig
-    state: present
+  ansible.builtin.command: yum -y install chkconfig
+  args:
+    creates: /usr/sbin/chkconfig
   when: ansible_facts.distribution_version == "2023"

--- a/roles/agent_install/tasks/agent/dependencies/redhat/install-redhat-dependencies.yml
+++ b/roles/agent_install/tasks/agent/dependencies/redhat/install-redhat-dependencies.yml
@@ -1,7 +1,7 @@
 - name: (RHEL) Install Kernel Headers (7/8)
-  ansible.builtin.yum:
-    name: "kernel-devel-{{ ansible_kernel }}"
-    state: present
+  ansible.builtin.command: yum -y install "kernel-devel-{{ ansible_kernel }}"
+  args:
+    creates: /usr/src/kernels/{{ ansible_kernel }}
   when: ansible_distribution_major_version in ["7", "8"]
 
 - name: (RHEL) Install Kernel Headers (9)
@@ -18,21 +18,21 @@
         key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}
 
     - name: (RHEL) Install epel
-      ansible.builtin.yum:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
-        state: present
+      ansible.builtin.command: yum -y install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+      args:
+        creates: /etc/yum.repos.d/epel.repo
       retries: 10
       delay: 3
-      register: result
-      until: result is not failed
+      register: agent_install_epel_result
+      until: agent_install_epel_result is not failed
 
     - name: (RHEL) Install dkms
-      ansible.builtin.yum:
-        name: dkms
-        state: present
+      ansible.builtin.command: yum -y install dkms
+      args:
+        creates: /usr/sbin/dkms
 
 - name: (RHEL) Install eBPF dependencies
-  ansible.builtin.yum:
-    name: clang,elfutils-libelf-devel,llvm
-    state: present
+  ansible.builtin.command: yum -y install clang elfutils-libelf-devel llvm
+  args:
+    creates: /usr/bin/clang
   when: agent_install_driver_type == "legacy_ebpf"


### PR DESCRIPTION
## Problem

On RHEL 7/8 and Amazon Linux, the dependency tasks use `ansible.builtin.yum` / `ansible.builtin.dnf`. On these distros those modules route through the dnf backend, which imports the `python3-dnf` bindings using the interpreter Ansible runs modules under. Those bindings are built only for the distro's system `platform-python` (3.6 on EL8) and are ABI-tied to it.

Recent `ansible-core` releases (2.17+) require a managed-node interpreter `>= 3.7`, so interpreter discovery on these hosts selects a newer Python (e.g. `python3.9`) that has **no** dnf bindings. The package tasks then fail at the first kernel-headers task:

```
(RHEL) Install Kernel Headers (7/8)
fatal: Could not import the dnf python module using /usr/bin/python3.9 ...
Please install `python3-dnf` package or ensure you have specified the correct ansible_python_interpreter.
```
```
(Amazon Linux) Install Kernel Headers
fatal: Could not detect which major revision of dnf is in use, which is required
to determine module backend ... specify use_backend ...
```

No single interpreter satisfies both constraints:
- `platform-python` 3.6 **has** the dnf bindings but is too old to run modern ansible-core module payloads (`SyntaxError: future feature annotations is not defined`).
- `python3.9` runs the payloads but has **no** dnf bindings.

So this can't be resolved by interpreter pinning — the only reliable fix is to not depend on the dnf python bindings for these installs.

## Change

Install the EL7/8 and Amazon Linux dependencies through the `yum` CLI via `ansible.builtin.command`, which works regardless of the controller's Python, with `creates:` for idempotency:

- `roles/agent_install/tasks/agent/dependencies/redhat/install-redhat-dependencies.yml`
- `roles/agent_install/tasks/agent/dependencies/amazon/install-amazon-dependencies.yml`

RHEL 9 is unchanged — it keeps the `dnf` module, because its system interpreter (3.9) ships the matching `python3-dnf` bindings. The expected `command-instead-of-module` lint warnings are added to `.ansible-lint-ignore`.

## Testing

- `yamllint` and `ansible-lint` (production profile) pass on both changed files.
- Verified the failure reproduces with `ansible-core` 2.18 on RHEL 8 / Amazon Linux 2 hosts, and that installing via the `yum` CLI completes the dependency stage where the `dnf`/`yum` module aborts.